### PR TITLE
fix: handle None root_model in lm_handler

### DIFF
--- a/rlm/core/lm_handler.py
+++ b/rlm/core/lm_handler.py
@@ -54,7 +54,7 @@ class LMRequestHandler(StreamRequestHandler):
         usage_summary = client.get_last_usage()
         return LMResponse.success_response(
             chat_completion=RLMChatCompletion(
-                root_model=request.model,
+                root_model=request.model or client.model_name,
                 prompt=request.prompt,
                 response=content,
                 usage_summary=usage_summary,
@@ -80,7 +80,7 @@ class LMRequestHandler(StreamRequestHandler):
 
         chat_completions = [
             RLMChatCompletion(
-                root_model=request.model,
+                root_model=request.model or client.model_name,
                 prompt=prompt,
                 response=content,
                 usage_summary=usage_summary,


### PR DESCRIPTION
## Summary

- Fix TypeError when printing sub-call with None `root_model`
- When users call `llm_query(prompt)` without specifying a model, `request.model` is `None`
- The handler correctly uses the default client but was recording `None` as `root_model`
- Now falls back to `client.model_name` when `request.model` is `None`

## Error

```
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 result = rlm.completion(
      2     prompt=reviews,
      3     root_prompt="What percentage of these reviews are positive vs negative?"
      4 )
      5 print(result.response)

File ~/development/github.com/XiaoConstantine/rlm/rlm/core/rlm.py:191, in RLM.completion(self, prompt, root_prompt)
    188     self.logger.log(iteration)
    190 # Verbose output for this iteration
--> 191 self.verbose.print_iteration(iteration, i + 1)
    193 if final_answer:
    194     time_end = time.perf_counter()

File ~/development/github.com/XiaoConstantine/rlm/rlm/logger/verbose.py:320, in VerbosePrinter.print_iteration(self, iteration, iteration_num)
    318 # Print any sub-calls made during this code block
    319 for call in code_block.result.rlm_calls:
--> 320     self.print_subcall(
    321         model=call.root_model,
    322         prompt_preview=_to_str(call.prompt) if call.prompt else "",
    323         response_preview=_to_str(call.response) if call.response else "",
    324         execution_time=call.execution_time,
    325     )

File ~/development/github.com/XiaoConstantine/rlm/rlm/logger/verbose.py:280, in VerbosePrinter.print_subcall(self, model, prompt_preview, response_preview, execution_time)
    278 header.append("  ↳ ", style=STYLE_SECONDARY)
    279 header.append("Sub-call: ", style=STYLE_SECONDARY)
--> 280 header.append(model, style=STYLE_ACCENT)
    281 if execution_time:
    282     header.append(f"  ({execution_time:.2f}s)", style=STYLE_MUTED)

File ~/development/github.com/XiaoConstantine/rlm/.venv/lib/python3.11/site-packages/rich/text.py:979, in Text.append(self, text, style)
    968 """Add text with an optional style.
    978 if not isinstance(text, (str, Text)):
--> 979     raise TypeError("Only str or Text can be appended to Text")

TypeError: Only str or Text can be appended to Text
```