### PR TITLE
fix: use async clients for acompletion methods

### DIFF
--- a/rlm/clients/openai.py
+++ b/rlm/clients/openai.py
@@ -37,6 +37,7 @@ class OpenAIClient(BaseLM):
 
         # For vLLM, set base_url to local vLLM server address.
         self.client = openai.OpenAI(api_key=api_key, base_url=base_url)
+        self.async_client = openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
         self.model_name = model_name
 
         # Per-model usage tracking
@@ -75,7 +76,7 @@ class OpenAIClient(BaseLM):
         if not model:
             raise ValueError("Model name is required for OpenAI client.")
 
-        response = await self.client.chat.completions.create(model=model, messages=messages)
+        response = await self.async_client.chat.completions.create(model=model, messages=messages)
         self._track_cost(response, model)
         return response.choices[0].message.content
 

--- a/rlm/clients/portkey.py
+++ b/rlm/clients/portkey.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import Any
 
-from portkey_ai import Portkey
+from portkey_ai import AsyncPortkey, Portkey
 from portkey_ai.api_resources.types.chat_complete_type import ChatCompletions
 
 from rlm.clients.base_lm import BaseLM
@@ -22,6 +22,7 @@ class PortkeyClient(BaseLM):
     ):
         super().__init__(model_name=model_name, **kwargs)
         self.client = Portkey(api_key=api_key, base_url=base_url)
+        self.async_client = AsyncPortkey(api_key=api_key, base_url=base_url)
         self.model_name = model_name
 
         # Per-model usage tracking
@@ -61,7 +62,7 @@ class PortkeyClient(BaseLM):
         if not model:
             raise ValueError("Model name is required for Portkey client.")
 
-        response = await self.client.chat.completions.create(model=model, messages=messages)
+        response = await self.async_client.chat.completions.create(model=model, messages=messages)
         self._track_cost(response, model)
         return response.choices[0].message.content
 


### PR DESCRIPTION
## Problem
  Running async code paths (e.g., REPL chunk investigation) produced:
  `Error: object ChatCompletion can't be used in 'await' expression`

## Changes
- Fixed `acompletion()` methods in OpenAI and Portkey clients that were incorrectly awaiting synchronous client responses
- Added `AsyncOpenAI` and `AsyncPortkey` clients for proper async support, matching existing Anthropic client pattern

Specifically:
  - `rlm/clients/openai.py`: Initialize `self.async_client` with `openai.AsyncOpenAI()`, use in `acompletion()`
  - `rlm/clients/portkey.py`: Initialize `self.async_client` with `AsyncPortkey()`, use in `acompletion()`

The Anthropic client already followed this pattern correctly with both `anthropic.Anthropic()` and `anthropic.AsyncAnthropic()`. OpenAI and Portkey now match.