### PR TITLE
fix: resolve FINAL_VAR to actual variable value instead of returning …

### DIFF
--- a/rlm/core/rlm.py
+++ b/rlm/core/rlm.py
@@ -16,8 +16,8 @@ from rlm.core.types import (
 from rlm.environments import BaseEnv, get_environment
 from rlm.logger import RLMLogger, VerbosePrinter
 from rlm.utils.parsing import (
+    check_for_final_answer,
     find_code_blocks,
-    find_final_answer,
     format_iteration,
 )
 from rlm.utils.prompts import (
@@ -186,7 +186,7 @@ class RLM:
                 )
 
                 # Check if RLM is done and has a final answer.
-                final_answer = find_final_answer(iteration.response)
+                final_answer = check_for_final_answer(iteration.response, environment.locals)
                 iteration.final_answer = final_answer
 
                 # If logger is used, log the iteration.


### PR DESCRIPTION
…tuple

The find_final_answer() function returns a tuple ("FINAL_VAR", "var_name"), but the caller was passing this tuple directly as the final answer instead of resolving the variable from environment.locals.

- Refactor check_for_final_answer() to take env_locals dict directly
- Remove broken logger.log_tool_execution() dependency (method didn't exist)
- Use check_for_final_answer() in rlm.py to properly resolve FINAL_VAR