### PR TITLE
fix: use self.client.base_url in acompletion method

### DIFF
--- a/rlm/clients/openai.py
+++ b/rlm/clients/openai.py
@@ -84,7 +84,7 @@ class OpenAIClient(BaseLM):
             raise ValueError("Model name is required for OpenAI client.")
 
         extra_body = {}
-        if self.base_url == DEFAULT_PRIME_INTELLECT_BASE_URL:
+        if self.client.base_url == DEFAULT_PRIME_INTELLECT_BASE_URL:
             extra_body["usage"] = {"include": True}
 
         response = await self.async_client.chat.completions.create(


### PR DESCRIPTION
## Summary
- Fixed `AttributeError: 'OpenAIClient' object has no attribute 'base_url'` in async completion
- The `acompletion` method was using `self.base_url` instead of `self.client.base_url`
- Matches the sync `completion` method which correctly uses `self.client.base_url`

This bug caused recursive LLM calls to fail repeatedly:
```
["Error: 'OpenAIClient' object has no attribute 'base_url'", 
 "Error: 'OpenAIClient' object has no attribute 'base_url'", ...]
```