### PR TITLE
fix: ensure docker env uses shared workspace dir

### DIFF
--- a/rlm/environments/docker_repl.py
+++ b/rlm/environments/docker_repl.py
@@ -197,7 +197,9 @@ class DockerREPL(NonIsolatedEnv):
         self.proxy_server: HTTPServer | None = None
         self.proxy_thread: threading.Thread | None = None
         self.proxy_port: int = 0
-        base_dir = os.environ.get("RLM_DOCKER_WORKSPACE_DIR", os.path.join(os.getcwd(), ".rlm_workspace"))
+        base_dir = os.environ.get(
+            "RLM_DOCKER_WORKSPACE_DIR", os.path.join(os.getcwd(), ".rlm_workspace")
+        )
         os.makedirs(base_dir, exist_ok=True)
         self.temp_dir = tempfile.mkdtemp(prefix="docker_repl_", dir=base_dir)
         self.pending_calls: list[RLMChatCompletion] = []


### PR DESCRIPTION
Sometimes the temporary directory used for Docker REPLs might not be shared by Docker. 
The temp dir can't be mounted into the container at /workspace, so the context is not available to the RLM. 

Now, temp directories are created under a shared path—either from the RLM_DOCKER_WORKSPACE_DIR environment variable or a .rlm_workspace folder in the current working directory.

This ensures the workspace is always mountable by Docker, making things work reliably and letting you override the location if needed. 