### PR TITLE
fix: handle BrokenPipeError in LMHandler during parallel execution

### DIFF
--- a/rlm/core/lm_handler.py
+++ b/rlm/core/lm_handler.py
@@ -39,7 +39,7 @@ class LMRequestHandler(StreamRequestHandler):
 
             self._safe_send(response)
 
-        except (BrokenPipeError, ConnectionError, ConnectionResetError, OSError) as e:
+        except (BrokenPipeError, ConnectionError, ConnectionResetError, OSError):
             # Client disconnected - this is expected during parallel execution
             # when workers complete and close their sockets. Silently ignore.
             pass


### PR DESCRIPTION
## Summary
- Fix `BrokenPipeError` that occurred during parallel evaluation runs (e.g., `--parallel 9`)
- Add `_safe_send()` helper method that catches connection errors gracefully
- Handle connection errors separately from other exceptions to prevent cascading failures

## Problem
When running parallel evaluations with the RLM eval harness:
```
python use_cases/example_workflows/eval_harness.py rlm_oolong ... --parallel 9
```

Multiple workers connect to the LMHandler socket server simultaneously. When workers complete and close their sockets (or the connection is interrupted), the server would raise `BrokenPipeError` when trying to send responses. The error handler would then try to send an error response on the same broken socket, causing another `BrokenPipeError`.

## Solution
1. Added a `_safe_send()` helper that wraps `socket_send()` and catches connection errors
2. Handle `BrokenPipeError`, `ConnectionError`, `ConnectionResetError`, and `OSError` separately - these are expected during parallel execution and can be silently ignored
3. Use `_safe_send()` for all socket operations in the `handle()` method

## Test plan
- [x] Verified module imports correctly
- [x] RLM test suite passes (143 tests)
- [ ] Manual test with `--parallel 9` to confirm BrokenPipeError is no longer logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)