### PR TITLE
refactor: rename llm_calls to rlm_calls in REPLResult class for clarity

### DIFF
--- a/rlm/core/types.py
+++ b/rlm/core/types.py
@@ -123,7 +123,7 @@ class REPLResult:
     stderr: str
     locals: dict
     execution_time: float
-    llm_calls: list["RLMChatCompletion"]
+    rlm_calls: list[RLMChatCompletion]
 
     def __init__(
         self,
@@ -131,7 +131,7 @@ class REPLResult:
         stderr: str,
         locals: dict,
         execution_time: float = None,
-        rlm_calls: list["RLMChatCompletion"] = None,
+        rlm_calls: list[RLMChatCompletion] = None,
     ):
         self.stdout = stdout
         self.stderr = stderr


### PR DESCRIPTION
- Updated the attribute name in the REPLResult class to better reflect its purpose.
- Adjusted the constructor to match the new naming convention.