### PR TITLE
feat: add Claude Code configuration, skills, and agents

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,99 @@
+---
+name: code-reviewer
+description: "Use this agent when code changes need review for quality, security, and maintainability. Focuses on changes in the current branch/PR.
+
+Examples:
+
+<example>
+user: \"Review my changes before I push\"
+assistant: \"I'll launch the code-reviewer agent to analyze your branch changes.\"
+</example>
+
+<example>
+user: \"Review PR #42\"
+assistant: \"Let me launch the code-reviewer to review PR #42's diff.\"
+</example>"
+tools: Read, Grep, Glob, Bash
+model: sonnet
+memory: project
+skills:
+  - domain
+---
+
+You are a code reviewer for the RLM (Recursive Language Models) Python library. You focus on changes in the current branch compared to its base.
+
+## Review Process
+
+### Step 1: Get the Diff
+
+Run `git diff main...HEAD` (or `gh pr diff <number>` if a PR number is provided).
+
+### Step 2: Analyze Changes
+
+For each changed file, review for:
+
+#### Correctness
+- Socket protocol errors (wrong byte encoding, missing length prefix)
+- REPL execution issues (namespace pollution, missing cleanup)
+- Parsing bugs (FINAL_VAR regex, code block extraction)
+- LM client errors (wrong API call patterns, missing usage tracking)
+- Environment lifecycle issues (missing setup/cleanup, state leaks)
+
+#### Security
+- Code execution safety (sandboxing, restricted builtins in REPL)
+- API key exposure (keys in code instead of env vars)
+- Arbitrary code execution risks in environments
+
+#### Python Patterns
+- Proper async/sync handling (acompletion vs completion)
+- Type hints on public functions
+- Abstract method implementation completeness
+- Resource cleanup (sockets, sandboxes, connections)
+
+#### Performance
+- Unnecessary serialization/deserialization
+- Blocking I/O in async paths
+- Missing batched calls where sequential could be concurrent
+- Socket connection reuse
+
+#### Code Quality
+- Ruff compliance (E, F, I, W, B, UP rules, line-length 100)
+- Dead code (unused imports, variables, functions)
+- Copy-pasted logic that should be extracted
+- Backward compatibility considerations for library consumers
+
+#### RLM-Specific
+- Context reduction principle violations (data in prompt instead of context)
+- FINAL_VAR mechanism correctness
+- Depth routing configuration
+- Environment ↔ LM Handler communication protocol
+
+### Step 3: Report
+
+```
+## Code Review: [branch or PR identifier]
+
+### Critical (fix before merge)
+- [file:line] Description
+
+### Warning (should fix)
+- [file:line] Description
+
+### Suggestion (nice to have)
+- [file:line] Description
+
+### What looks good
+- Brief positive observations
+
+### Summary
+[1-2 sentence overall assessment]
+```
+
+## Rules
+
+- Only flag issues in the diff, not pre-existing code
+- Don't flag style issues ruff would catch
+- Be specific -- provide exact fix, not just "this is wrong"
+- If no issues found, say so clearly
+- Keep output under 100 lines unless many critical findings
+- No emojis unless the user uses them

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,120 @@
+---
+name: test-writer
+description: "Use this agent when writing tests for the RLM library. Understands pytest patterns, mock LM clients, REPL testing, and environment testing.
+
+Examples:
+
+<example>
+user: \"Write tests for the new Gemini client\"
+assistant: \"I'll launch the test-writer agent to design tests for the Gemini client.\"
+</example>
+
+<example>
+user: \"Add tests for the parsing edge cases\"
+assistant: \"I'll launch the test-writer to create tests for parsing edge cases.\"
+</example>"
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+memory: project
+skills:
+  - domain
+---
+
+You are a test engineer for the RLM (Recursive Language Models) Python library. You write tests that prove features work using real code paths.
+
+## Critical: Never Replicate Production Logic
+
+Tests must NEVER copy/replicate production logic. Always import and call the actual production code. If production code is hard to test directly, extract the logic into a testable helper and test that helper.
+
+## Project Test Setup
+
+- **Runner**: pytest (`uv run pytest`)
+- **Config**: `pyproject.toml` sets `testpaths = ["tests"]`
+- **Location**: All tests in `tests/` directory
+- **Mock LM**: `tests/mock_lm.py` provides a mock LM client for testing
+
+### Common Mock Patterns
+
+```python
+# Use the project's mock LM (tests/mock_lm.py)
+from tests.mock_lm import MockLM
+
+# Mock an LM client for RLM completion tests
+mock_lm = MockLM(responses=["expected response"])
+rlm = RLM(lm=mock_lm, environment="local")
+result = rlm.completion(prompt="test", root_prompt="test")
+
+# Mock socket communication for environment tests
+from unittest.mock import patch, MagicMock
+
+@patch("rlm.core.comms_utils.socket_send")
+@patch("rlm.core.comms_utils.socket_recv")
+def test_lm_request(mock_recv, mock_send):
+    mock_recv.return_value = {"response": "test"}
+    # ... test logic
+```
+
+### What to Mock vs What to Run Real
+
+**Mock (expensive/nondeterministic):**
+- LLM API calls (OpenAI, Anthropic, Gemini, etc.)
+- Cloud sandbox creation (Modal, E2B, Prime, Daytona)
+- Network/socket operations
+- External HTTP requests
+
+**Run real (pure logic, deterministic):**
+- REPL code execution (LocalREPL)
+- Parsing functions (FINAL_VAR extraction, code block parsing)
+- Context serialization/deserialization
+- Type conversions and dataclass operations
+- Usage tracking and aggregation
+- Prompt construction
+
+## Test Design Principles
+
+### Behavior-focused test names
+```python
+# Good
+def test_final_var_extracts_variable_at_line_start():
+def test_local_repl_preserves_state_across_executions():
+def test_depth_routing_sends_to_sub_model():
+
+# Bad
+def test_parsing_works():
+def test_repl_returns_result():
+```
+
+### Test the public API
+Focus on `RLM.completion()`, `RLM.acompletion()`, client `.completion()`, and environment `.execute_code()` rather than internal helpers.
+
+### Environment testing
+- Test `setup()` initializes correct globals (context, llm_query, FINAL_VAR)
+- Test `execute_code()` returns proper `REPLResult`
+- Test `load_context()` makes data accessible
+- Test `cleanup()` releases resources
+
+### Client testing
+- Test both string and message list prompt formats
+- Test usage tracking (calls, tokens)
+- Test error handling (missing API key, rate limits)
+
+## File Naming Convention
+
+- Test files: `tests/test_{module_name}.py`
+- Subdirectories mirror source: `tests/clients/`, `tests/repl/`
+
+## Running Tests
+
+```bash
+uv run pytest                          # All tests
+uv run pytest tests/test_parsing.py    # Single file
+uv run pytest -k test_final_var        # Single test by name
+```
+
+## Anti-Patterns
+
+- Don't create a test that only asserts a mock was called with certain args
+- Don't write tests for trivial getters/setters
+- Don't mock everything -- if setup is complex, write an integration test
+- Don't duplicate test logic across files -- use shared fixtures
+- Don't test internal implementation details -- test behavior through the public API

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(ruff:*)",
+      "Bash(uv run ruff:*)",
+      "Bash(uv run pytest:*)",
+      "Bash(uv run pre-commit:*)",
+      "Bash(uv sync:*)",
+      "Bash(pytest:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(gh:*)",
+      "Bash(make:*)",
+      "Read",
+      "Glob",
+      "Grep"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(cat | grep -o '\"file_path\":\"[^\"]*\"' | head -1 | cut -d'\"' -f4); if [[ \"$file\" == *.py ]]; then ruff check --fix \"$file\" && ruff format \"$file\" && ruff check \"$file\"; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/architecture-designer/SKILL.md
+++ b/.claude/skills/architecture-designer/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: architecture-designer
+description: "Use when designing new components, reviewing architecture, or making structural decisions about the RLM library. Invoke for environment design, client architecture, protocol changes, ADRs, or evaluating trade-offs."
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+# Architecture Designer
+
+Architect specializing in system design, design patterns, and architectural decision-making for the RLM library.
+
+## When to Use
+
+- Designing a new environment or LM client
+- Choosing between architectural patterns for a feature
+- Reviewing existing architecture for improvements
+- Creating Architecture Decision Records (ADRs)
+- Evaluating trade-offs between approaches
+- Planning protocol changes (socket, HTTP broker)
+
+## Core Workflow
+
+1. **Understand requirements** - Functional, non-functional, constraints
+2. **Identify patterns** - Match requirements to architectural patterns
+3. **Design** - Create architecture with trade-offs documented
+4. **Document** - Write ADRs for key decisions
+5. **Review** - Validate against existing codebase patterns
+
+## Reference Guide
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Architecture Patterns | `references/architecture-patterns.md` | Choosing patterns, comparing approaches |
+| ADR Template | `references/adr-template.md` | Documenting architectural decisions |
+
+## RLM-Specific Architecture Concerns
+
+### Environment Design
+- Non-isolated vs isolated execution models
+- State persistence across code execution rounds
+- Resource cleanup and lifecycle management
+- Sub-LM call routing (socket vs HTTP broker)
+
+### Client Design
+- Provider abstraction (BaseLM interface)
+- Usage tracking consistency
+- Prompt format handling (string vs message list)
+- Error propagation patterns
+
+### Communication Protocol
+- Length-prefixed JSON over TCP (non-isolated)
+- HTTP broker with polling (isolated/cloud)
+- Serialization format decisions
+- Connection management and pooling
+
+### Extension Points
+- New environment registration pattern
+- New client registration pattern
+- Optional dependency management (extras in pyproject.toml)
+
+## Constraints
+
+### MUST DO
+- Document significant decisions with ADRs
+- Evaluate trade-offs, not just benefits
+- Consider backward compatibility for library consumers
+- Plan for failure modes and cleanup
+- Match existing patterns in the codebase
+- Keep the dependency footprint minimal
+
+### MUST NOT DO
+- Over-engineer for hypothetical scale
+- Choose patterns without evaluating alternatives
+- Ignore existing conventions in the codebase
+- Add required dependencies when optional extras suffice
+- Break the public API without clear justification
+
+## Output Format
+
+When designing architecture, provide:
+1. Requirements summary (functional + non-functional)
+2. High-level design (ASCII diagrams preferred)
+3. Key decisions with trade-offs (ADR format for significant ones)
+4. Implementation approach with file locations
+5. Risks and mitigation strategies

--- a/.claude/skills/architecture-designer/references/adr-template.md
+++ b/.claude/skills/architecture-designer/references/adr-template.md
@@ -1,0 +1,99 @@
+# ADR Template
+
+## Format
+
+```markdown
+# ADR-{number}: {Title}
+
+## Status
+[Proposed | Accepted | Deprecated | Superseded by ADR-XXX]
+
+## Context
+[Describe the situation and forces at play. What is the problem?
+What constraints exist? What are we trying to achieve?]
+
+## Decision
+[State the decision clearly. What are we going to do?]
+
+## Consequences
+
+### Positive
+- [Benefit 1]
+- [Benefit 2]
+
+### Negative
+- [Drawback 1]
+- [Drawback 2]
+
+### Neutral
+- [Side effect that is neither good nor bad]
+
+## Alternatives Considered
+[What other options were evaluated and why were they rejected?]
+
+## References
+- [Link to relevant documentation]
+```
+
+## Example: Environment Communication
+
+```markdown
+# ADR-001: Use HTTP broker for isolated environment communication
+
+## Status
+Accepted
+
+## Context
+Isolated environments (Modal, E2B, Prime) run code in cloud sandboxes
+that cannot directly connect to the host's TCP socket server. We need a
+way for sandbox code to make sub-LM calls back to the host.
+
+Options:
+- WebSocket connection from sandbox to host
+- HTTP broker with polling
+- gRPC bidirectional streaming
+
+## Decision
+Use an HTTP broker pattern with Flask inside the sandbox and a polling
+thread on the host.
+
+## Consequences
+
+### Positive
+- Works through any tunnel/port forwarding mechanism
+- Simple HTTP -- no special protocol support needed
+- Each cloud provider's tunnel mechanism works (Modal encrypted_ports, etc.)
+- Easy to debug with standard HTTP tools
+
+### Negative
+- Polling adds latency (~100ms intervals)
+- State management across HTTP requests requires threading.Event
+- More moving parts than direct socket
+
+### Neutral
+- Broker server adds Flask as a dependency inside sandbox
+- Pattern is consistent across all isolated environments
+
+## Alternatives Considered
+
+**WebSocket**
+- Rejected: Not all cloud sandbox tunnels support WebSocket upgrades
+- Would require additional dependency management inside sandboxes
+
+**gRPC**
+- Rejected: Heavy dependency, complex setup inside sandboxes
+- Overkill for request-response pattern
+
+## References
+- rlm/environments/modal_repl.py (reference implementation)
+- rlm/core/comms_utils.py (socket protocol for comparison)
+```
+
+## Naming Convention
+
+```
+docs/adr/
+├── 0001-http-broker-for-isolated-envs.md
+├── 0002-length-prefixed-socket-protocol.md
+└── README.md
+```

--- a/.claude/skills/architecture-designer/references/architecture-patterns.md
+++ b/.claude/skills/architecture-designer/references/architecture-patterns.md
@@ -1,0 +1,131 @@
+# Architecture Patterns Reference
+
+## Pattern Comparison
+
+| Pattern | Best For | Trade-offs |
+|---------|----------|------------|
+| **Non-Isolated Exec** | Local dev, simple setup | Fast; no sandboxing |
+| **Isolated Sandbox** | Untrusted code, cloud | Safe; operational complexity |
+| **Direct Socket** | Same-machine comms | Low latency; no network boundary |
+| **HTTP Broker** | Cross-boundary comms | Works anywhere; polling overhead |
+| **Plugin/Registry** | Extensibility | Clean API; discovery complexity |
+
+## RLM Environment Patterns
+
+### Non-Isolated (LocalREPL)
+
+```
+┌──────────────┐
+│   RLM Core   │
+│   ┌────────┐ │       TCP Socket
+│   │ REPL   │─┼──────────────────► LMHandler
+│   │ exec() │ │
+│   └────────┘ │
+└──────────────┘
+```
+
+**When to use**: Development, trusted code, low-latency needs
+**Pros**: Simple, fast, no external deps
+**Cons**: No isolation, code runs in same process
+
+### Isolated (Modal/E2B/Prime/Daytona)
+
+```
+┌─────────────────┐          ┌──────────────────┐
+│   Host          │          │   Cloud Sandbox  │
+│   ┌───────────┐ │  HTTP    │   ┌────────────┐ │
+│   │ Poller    │─┼──────────┼──►│ Broker     │ │
+│   │           │ │  tunnel  │   │ /enqueue   │ │
+│   └─────┬─────┘ │          │   │ /pending   │ │
+│         │       │          │   │ /respond   │ │
+│   ┌─────▼─────┐ │          │   └─────┬──────┘ │
+│   │ LMHandler │ │          │   ┌─────▼──────┐ │
+│   └───────────┘ │          │   │ Exec Script│ │
+└─────────────────┘          │   └────────────┘ │
+                             └──────────────────┘
+```
+
+**When to use**: Untrusted code, cloud execution, resource isolation
+**Pros**: Safe, scalable, any cloud provider
+**Cons**: Latency (polling), state serialization, tunnel setup
+
+### Docker (hybrid)
+
+```
+┌──────────────────┐
+│   Host           │
+│   ┌────────────┐ │       ┌───────────────┐
+│   │ DockerREPL │─┼──────►│   Container   │
+│   └──────┬─────┘ │       │   exec code   │
+│   ┌──────▼─────┐ │       └───────────────┘
+│   │ LMHandler  │ │
+│   └────────────┘ │
+└──────────────────┘
+```
+
+**When to use**: Local isolation without cloud dependency
+**Pros**: Isolated, reproducible, local
+**Cons**: Docker required, container overhead
+
+## Client Patterns
+
+### Provider Abstraction
+
+```
+         BaseLM (abstract)
+        ┌───────────────────┐
+        │ completion()      │
+        │ acompletion()     │
+        │ get_usage_summary()│
+        │ get_last_usage()  │
+        └───────┬───────────┘
+                │
+    ┌───────────┼───────────┬────────────┐
+    │           │           │            │
+OpenAI    Anthropic    Gemini      Portkey
+```
+
+**Pattern**: Template Method / Strategy
+**Extension**: Add new client by inheriting BaseLM, implementing abstract methods, registering in `__init__.py`
+
+### Usage Tracking
+
+All clients must track per-model usage internally and expose via standard interface. This enables cost monitoring and optimization across providers.
+
+## Communication Patterns
+
+### Length-Prefixed Protocol (TCP)
+
+```
+┌──────────┬──────────────────────┐
+│ 4 bytes  │   UTF-8 JSON payload │
+│ (length) │                      │
+└──────────┴──────────────────────┘
+```
+
+**When to use**: Same-machine, low-latency, reliable
+**Pros**: Simple, fast, no HTTP overhead
+**Cons**: Custom protocol, no built-in auth
+
+### HTTP Broker (REST)
+
+```
+POST /enqueue   → Submit LLM request (blocks)
+GET  /pending   → Poll for requests
+POST /respond   → Submit response
+GET  /health    → Health check
+```
+
+**When to use**: Cross-network boundary, cloud sandboxes
+**Pros**: Standard HTTP, works through firewalls/tunnels
+**Cons**: Polling latency, more complex state management
+
+## Decision Matrix
+
+| Need | Pattern | Example |
+|------|---------|---------|
+| New LM provider | Client abstraction | Add `rlm/clients/new_provider.py` |
+| New cloud sandbox | Isolated environment | Add `rlm/environments/new_sandbox.py` |
+| New local executor | Non-isolated environment | Add `rlm/environments/new_local.py` |
+| Protocol change | Socket/HTTP modification | Modify `rlm/core/comms_utils.py` |
+| New REPL function | Environment globals | Add to `setup()` in environment |

--- a/.claude/skills/domain/SKILL.md
+++ b/.claude/skills/domain/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: domain
+description: Load domain-specific context for RLM library areas. Use PROACTIVELY when working on core RLM logic, environments, LM clients, or the communication architecture. Saves significant context window by loading only what's needed.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+# Domain Context Loader
+
+Loads focused domain knowledge before working on specific library areas. Keeps context lean by loading only what's needed.
+
+## Usage
+
+```
+/domain core           # RLM completion flow, REPL, FINAL_VAR, context reduction
+/domain environments   # Environment development: LocalREPL, sandboxes, broker pattern
+/domain clients        # LM client development: BaseLM, usage tracking, providers
+/domain architecture   # Socket protocol, HTTP broker, environment ↔ LM Handler comms
+/domain                # Auto-detect from conversation context
+```
+
+## Auto-Detection Rules
+
+When invoked without argument, detect domain from context:
+
+| Keywords in Conversation | Domain to Load |
+|-------------------------|----------------|
+| completion, prompt, root_prompt, context, FINAL_VAR, depth, iteration | core |
+| environment, repl, sandbox, execute_code, setup, cleanup, modal, e2b, docker, daytona, prime | environments |
+| client, lm, openai, anthropic, gemini, portkey, litellm, completion, acompletion, usage | clients |
+| socket, handler, broker, comms, tunnel, protocol, lm_handler, polling | architecture |
+
+## Multi-Domain Loading
+
+Some tasks span domains. Load multiple when needed:
+
+| Task | Domains to Load |
+|------|-----------------|
+| "Add a new LM client" | clients |
+| "Build a new sandbox environment" | environments + architecture |
+| "Debug sub-LM call routing" | core + architecture |
+| "Fix FINAL_VAR parsing" | core |
+| "Add batched completion support" | core + clients |
+
+## Action Steps
+
+1. **Identify domain(s)** from argument or auto-detection
+2. **Read the domain doc(s)** from `.claude/skills/domain/docs/`
+3. **Check the Learnings section** for recent discoveries
+4. **Summarize key points** relevant to the current task
+5. **Proceed with the task** using loaded context
+
+## Available Domain Docs
+
+| Domain | File | Coverage |
+|--------|------|----------|
+| core | `docs/core.md` | RLM completion flow, REPL execution, FINAL_VAR, context reduction, depth routing |
+| environments | `docs/environments.md` | Base classes, LocalREPL, isolated sandboxes, broker pattern, state management |
+| clients | `docs/clients.md` | BaseLM interface, provider implementations, usage tracking, configuration |
+| architecture | `docs/architecture.md` | Socket protocol, HTTP broker, environment ↔ LM Handler communication |
+
+## Continuous Improvement
+
+These docs are **living documents**. Help them evolve:
+
+### When You Discover Something New
+
+If you find domain knowledge NOT in the docs:
+
+1. **Complete your task** using what you discovered
+2. **Add to Learnings** in the relevant doc:
+   ```markdown
+   ## Learnings
+   - [YYYY-MM-DD] Your discovery here
+   ```
+
+### When Docs Are Wrong or Outdated
+
+1. **Note the issue** in your response
+2. **Add to Learnings** with correction
+3. **Suggest the fix** for user approval

--- a/.claude/skills/domain/docs/architecture.md
+++ b/.claude/skills/domain/docs/architecture.md
@@ -1,0 +1,98 @@
+# Architecture Domain
+
+How environments communicate with the LM Handler for sub-LM calls during REPL execution.
+
+## Socket Protocol (Non-Isolated Environments)
+
+Non-isolated environments like `LocalREPL` communicate directly with the `LMHandler` via TCP sockets using a length-prefixed JSON protocol.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Host Machine                                                       │
+│  ┌─────────────┐       Socket (TCP)        ┌──────────────────────┐ │
+│  │   RLM       │◄──────────────────────────►  LMHandler           │ │
+│  │  (main)     │                           │  (ThreadingTCPServer)│ │
+│  └─────────────┘                           └──────────────────────┘ │
+│        │                                            ▲               │
+│        ▼                                            │               │
+│  ┌─────────────┐       Socket (TCP)                 │               │
+│  │ LocalREPL   │────────────────────────────────────┘               │
+│  │ (exec code) │  llm_query() → send_lm_request()                   │
+│  └─────────────┘                                                    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Protocol Format
+
+`4-byte big-endian length prefix + UTF-8 JSON payload`
+
+```python
+# From rlm/core/comms_utils.py
+def socket_send(sock: socket.socket, data: dict) -> None:
+    payload = json.dumps(data).encode("utf-8")
+    sock.sendall(struct.pack(">I", len(payload)) + payload)
+```
+
+### Request Flow
+
+1. Environment's `llm_query(prompt)` is called during code execution
+2. Creates `LMRequest` dataclass and calls `send_lm_request(address, request)`
+3. Opens TCP connection to `LMHandler` at `(host, port)`
+4. Sends length-prefixed JSON request
+5. `LMHandler` processes via `LMRequestHandler.handle()`
+6. Returns `LMResponse` with `RLMChatCompletion` or error
+
+### Key Components
+
+- `LMHandler` (`rlm/core/lm_handler.py`): Multi-threaded TCP server wrapping LM clients
+- `LMRequest` / `LMResponse` (`rlm/core/comms_utils.py`): Typed request/response dataclasses
+- `send_lm_request()` / `send_lm_request_batched()`: Helper functions for socket communication
+
+## HTTP Broker Pattern (Isolated Environments)
+
+Isolated environments (Modal, E2B, Prime, Daytona) cannot directly connect to the host's socket server. They use an HTTP broker:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Host Machine                                                               │
+│  ┌─────────┐    Socket    ┌────────────┐    HTTP Poll    ┌────────────────┐ │
+│  │   RLM   │◄────────────►│  LMHandler │◄────────────────│   ModalREPL    │ │
+│  └─────────┘              └────────────┘                 │  (poller)      │ │
+│                                                          └────────────────┘ │
+│                                                                  │          │
+│                                                          HTTP (tunnel)      │
+│                                                                  │          │
+└──────────────────────────────────────────────────────────────────┼──────────┘
+                                                                   │
+┌──────────────────────────────────────────────────────────────────┼──────────┐
+│  Cloud Sandbox (Modal/E2B/Prime/Daytona)                         ▼          │
+│  ┌─────────────┐     HTTP (localhost)     ┌─────────────────────────────┐   │
+│  │ Exec Script │◄────────────────────────►│   Broker Server (Flask)     │   │
+│  │ (exec code) │     /enqueue, etc.       │   - /enqueue (submit req)   │   │
+│  └─────────────┘                          │   - /pending (poll reqs)    │   │
+│                                           │   - /respond (return resp)  │   │
+│                                           └─────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### How It Works
+
+1. **Sandbox Setup**: Environment creates a cloud sandbox with an HTTP broker server inside
+2. **Tunnel Exposure**: Broker is exposed via encrypted tunnel (e.g., Modal's `encrypted_ports`)
+3. **Code Execution**: When `llm_query()` is called inside sandbox, it POSTs to `http://localhost:8080/enqueue`
+4. **Request Queuing**: Broker queues the request and blocks waiting for response
+5. **Host Polling**: REPL on host polls `{tunnel_url}/pending` for new requests
+6. **LM Forwarding**: Host forwards requests to `LMHandler` via socket, gets response
+7. **Response Delivery**: Host POSTs response to `{tunnel_url}/respond`
+8. **Unblocking**: Broker unblocks the original `/enqueue` call with the response
+
+### Key Implementation Details
+
+- Broker runs as a Flask server inside the sandbox
+- Uses `threading.Event` for request/response synchronization
+- Poller thread on host runs in background with 100ms polling interval
+- State persistence via `dill` serialization to `/tmp/rlm_state.dill`
+
+## Learnings
+
+<!-- Claude: Add discoveries here as you work with the architecture -->

--- a/.claude/skills/domain/docs/clients.md
+++ b/.claude/skills/domain/docs/clients.md
@@ -1,0 +1,87 @@
+# Clients Domain
+
+LM client implementations live in `rlm/clients/`. All clients inherit from `BaseLM`.
+
+## BaseLM Interface
+
+**File**: `rlm/clients/base_lm.py`
+
+| Method | Purpose |
+|--------|---------|
+| `completion(prompt, model=None)` | Synchronous LLM call |
+| `acompletion(prompt, model=None)` | Async LLM call |
+| `get_usage_summary()` | Aggregated usage across all calls |
+| `get_last_usage()` | Usage from most recent call |
+
+### Prompt Format
+Clients must handle both:
+- `str` - Plain text prompt
+- `list[dict[str, Any]]` - Message list format (`[{"role": "user", "content": "..."}]`)
+
+## Available Clients
+
+| Client | File | Provider | Extra |
+|--------|------|----------|-------|
+| `OpenAIClient` | `openai.py` | OpenAI | core |
+| `AzureOpenAIClient` | `azure_openai.py` | Azure OpenAI | core |
+| `AnthropicClient` | `anthropic.py` | Anthropic | core |
+| `GeminiClient` | `gemini.py` | Google Gemini | core |
+| `PortkeyClient` | `portkey.py` | Portkey (multi-provider) | core |
+| `LiteLLMClient` | `litellm.py` | LiteLLM (multi-provider) | core |
+
+## Implementing a New Client
+
+### Requirements
+- Inherit from `BaseLM` in `rlm/clients/base_lm.py`
+- Implement all abstract methods: `completion`, `acompletion`, `get_usage_summary`, `get_last_usage`
+- Track per-model usage (calls, input/output tokens)
+- Handle both string and message list prompts
+- Register client in `rlm/clients/__init__.py`
+
+### Example Structure
+
+```python
+from rlm.clients.base_lm import BaseLM
+from rlm.core.types import ModelUsageSummary, UsageSummary
+
+class MyClient(BaseLM):
+    def __init__(self, api_key: str, model_name: str, **kwargs):
+        super().__init__(model_name=model_name, **kwargs)
+        # Initialize your client
+
+    def completion(self, prompt: str | list[dict[str, Any]], model: str | None = None) -> str:
+        # Handle both str and message list formats
+        # Track usage with _track_cost()
+        # Return response string
+
+    def get_usage_summary(self) -> UsageSummary:
+        # Return aggregated usage across all calls
+```
+
+### Configuration Guidelines
+- **Environment variables**: ONLY for API keys (document in README)
+- **Hardcode**: Default base URLs, reasonable defaults
+- **Arguments**: Essential customization via `__init__()`
+
+### Error Handling
+- Missing API key -> immediate `ValueError`, not graceful fallback
+- Rate limit / API error -> let it propagate (caller handles retry)
+- Invalid prompt format -> `TypeError`
+
+## Usage Tracking
+
+**Types**: `rlm/core/types.py`
+
+- `ModelUsageSummary`: Per-model stats (calls, input_tokens, output_tokens)
+- `UsageSummary`: Aggregated across all models
+
+Clients track usage internally and expose via `get_usage_summary()` / `get_last_usage()`.
+
+## Dependencies
+- Avoid new core dependencies
+- Use optional extras for non-essential features (e.g., `modal` extra in pyproject.toml)
+- Exception: tiny deps that simplify widely-used code
+
+## Learnings
+
+<!-- Claude: Add discoveries here as you work with clients -->

--- a/.claude/skills/domain/docs/core.md
+++ b/.claude/skills/domain/docs/core.md
@@ -1,0 +1,126 @@
+# Core Domain
+
+The RLM (Reasoning Language Model) framework provides recursive LLM reasoning with a Python REPL execution environment. The root LLM writes Python code in `` ```repl `` blocks, which execute in a sandboxed REPL. The LLM sees truncated outputs, iterates, and returns results via `FINAL_VAR()`.
+
+## Entry Point
+
+**File**: `rlm/core/rlm.py` -> `RLM` class
+
+```python
+from rlm import RLM
+
+rlm = RLM(
+    lm=client,              # BaseLM client instance
+    environment="local",    # or "modal", "e2b", "docker", "prime", "daytona"
+    max_iterations=30,      # max REPL iterations before stopping
+    setup_code="",          # Python code executed before LLM starts
+    other_backends=[],      # sub-model backend names for depth routing
+    other_backend_kwargs=[], # kwargs for sub-model backends
+)
+
+result, usage = rlm.completion(prompt=data, root_prompt="instructions")
+result, usage = await rlm.acompletion(prompt=data, root_prompt="instructions")
+```
+
+## Completion Flow
+
+```
+rlm.completion(prompt, root_prompt)
+    |
+    v
+1. Serialize `prompt` (dict/list/string) to JSON file
+2. Load into REPL namespace as `context` variable
+3. Execute `setup_code` in REPL (pre-loaded helpers)
+4. System prompt + context metadata -> LLM
+5. User prompt includes root_prompt quoted
+6. LLM writes ```repl code -> executes -> output fed back
+7. LLM iterates until FINAL_VAR(variable_name)
+8. RLM extracts value from REPL namespace -> returns
+```
+
+## Key Principle: Context Reduction
+
+Large data goes into `context` (REPL variable loaded from JSON), NOT into the prompt. The root LLM only sees metadata like "Your context is a dict with 330061 total characters, broken into chunks: [2120, 16516, ...]". Data is accessed via REPL code (`context["key"]`, etc.).
+
+### DO:
+- Put all data in `prompt` arg (becomes `context` in REPL) -- frames, schemas, datasets
+- Put helper functions in `setup_code` -- executed before LLM starts
+- Keep `root_prompt` small -- describe the task, list available functions, show output format
+
+### DON'T:
+- Put large data in `root_prompt` -- it bloats the LLM context window
+- Rely on the LLM to execute code verbatim from the prompt
+
+## REPL Environment Functions
+
+Functions injected into REPL globals:
+
+| Function | Purpose |
+|----------|---------|
+| `context` | The data payload (dict loaded from JSON) |
+| `llm_query(prompt)` | Query sub-LLM (~500K char capacity) |
+| `llm_query_batched(prompts: List[str])` | Concurrent sub-LLM queries, much faster |
+| `FINAL_VAR(variable_name)` | Return a REPL variable's value as final answer |
+| `print()` | Output visible to root LLM (truncated to 20K chars) |
+| Setup code functions | Defined in `setup_code`, immutable |
+
+## Setup Code Pattern
+
+```python
+setup_code = '''
+def my_helper(data, key):
+    """Helper the LLM calls during REPL execution."""
+    return data.get(key, "default")
+'''
+```
+
+Setup code runs via `exec()` before the LLM's first iteration. Functions are in the namespace but the root LLM cannot see their source -- it only knows they exist if told in the `root_prompt`.
+
+## FINAL_VAR Mechanism
+
+**File**: `rlm/utils/parsing.py`
+
+- Regex-parsed from LLM response: `^\s*FINAL_VAR\((.*?)\)`
+- Must be at start of a line, outside code blocks
+- When found, executes `print(FINAL_VAR('varname'))` in REPL to retrieve value
+- The variable must exist in REPL namespace
+
+## Depth Routing
+
+**File**: `rlm/core/lm_handler.py`
+
+- `depth=0` -> default backend (root LLM)
+- `depth=1` -> `other_backend_client` (sub-model)
+- Environment is created with `depth = rlm.depth + 1`
+- So REPL calls to `llm_query()`/`llm_query_batched()` auto-route to sub-model
+- Configure via: `RLM(other_backends=["openai"], other_backend_kwargs=[...])`
+
+## Debugging
+
+- Set `RLM_LOG_DIR=/path/to/logs` to write REPL execution logs
+- Set `RLM_VERBOSE=true` for verbose output
+- Logs include: REPL code executed, outputs, LLM responses per iteration
+- Check `max_iterations` setting (default 30) if RLM seems stuck
+
+## Common Issues
+
+1. **Context too large**: Move data to chunked format in `context`, let LLM process iteratively
+2. **FINAL_VAR not found**: Check it's at start of line, outside code blocks
+3. **Sub-model routing wrong**: Verify `other_backends` config and depth settings
+4. **Recursion limit**: May need increasing for large context serialization
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `rlm/core/rlm.py` | Main RLM class, completion orchestration |
+| `rlm/core/lm_handler.py` | LM Handler, depth routing, TCP server |
+| `rlm/core/types.py` | Dataclasses: REPLResult, UsageSummary, etc. |
+| `rlm/core/comms_utils.py` | Socket protocol, LMRequest/LMResponse |
+| `rlm/utils/parsing.py` | FINAL_VAR extraction, code block parsing |
+| `rlm/utils/prompts.py` | System prompt construction |
+| `rlm/utils/rlm_utils.py` | Context serialization utilities |
+
+## Learnings
+
+<!-- Claude: Add discoveries here as you work with RLM core -->

--- a/.claude/skills/domain/docs/environments.md
+++ b/.claude/skills/domain/docs/environments.md
@@ -1,0 +1,108 @@
+# Environments Domain
+
+Environment implementations live in `rlm/environments/`. They provide the execution context where LLM-generated code runs.
+
+## Base Classes
+
+**File**: `rlm/environments/base_env.py`
+
+| Base Class | When to Use | Key Methods |
+|------------|-------------|-------------|
+| `NonIsolatedEnv` | Local execution, same machine | `setup`, `load_context`, `execute_code` |
+| `IsolatedEnv` | Cloud sandboxes (Modal, E2B, Prime, Daytona) | `setup`, `load_context`, `execute_code` |
+
+## Available Environments
+
+| Environment | File | Type | Sandbox |
+|-------------|------|------|---------|
+| `LocalREPL` | `local_repl.py` | NonIsolated | Local Python exec() |
+| `ModalREPL` | `modal_repl.py` | Isolated | Modal cloud sandbox |
+| `E2BREPL` | `e2b_repl.py` | Isolated | E2B sandbox |
+| `PrimeREPL` | `prime_repl.py` | Isolated | Prime sandbox |
+| `DaytonaREPL` | `daytona_repl.py` | Isolated | Daytona workspace |
+| `DockerREPL` | `docker_repl.py` | Isolated | Local Docker container |
+
+## Implementing a New Environment
+
+### Requirements
+- Inherit from `NonIsolatedEnv` or `IsolatedEnv`
+- Implement all abstract methods: `setup`, `load_context`, `execute_code`
+- Return `REPLResult` from `execute_code`
+- Handle `lm_handler_address` for sub-LM calls via `llm_query()`
+- Implement `cleanup()` for resource management
+- Register in `rlm/environments/__init__.py`
+
+### State Management
+Environments must provide these globals to executed code:
+- `context`: The loaded context payload
+- `llm_query(prompt, model=None)`: For sub-LM calls
+- `llm_query_batched(prompts, model=None)`: For batched sub-LM calls
+- `FINAL_VAR(variable_name)`: For returning final answers
+
+### Non-Isolated Example
+
+```python
+from rlm.environments.base_env import NonIsolatedEnv
+from rlm.core.types import REPLResult
+
+class MyEnvironment(NonIsolatedEnv):
+    def __init__(self, lm_handler_address: tuple[str, int] | None = None,
+                 context_payload: dict | list | str | None = None, **kwargs):
+        super().__init__(**kwargs)
+        self.lm_handler_address = lm_handler_address
+        self.setup()
+        if context_payload:
+            self.load_context(context_payload)
+
+    def setup(self):
+        # Initialize execution namespace with llm_query, FINAL_VAR, etc.
+
+    def load_context(self, context_payload: dict | list | str):
+        # Make context available to executed code
+
+    def execute_code(self, code: str) -> REPLResult:
+        # Execute code and return REPLResult
+
+    def cleanup(self):
+        # Clean up resources
+```
+
+### Isolated Environment Pattern (HTTP Broker)
+
+Isolated environments can't directly connect to the host's socket server. They use an HTTP broker:
+
+1. **Create broker server** - Flask/HTTP server with `/enqueue`, `/pending`, `/respond` endpoints
+2. **Expose tunnel** - Use provider's tunnel/port forwarding to expose broker to host
+3. **Implement poller** - Background thread on host to poll and forward requests
+4. **Build exec script** - Script that runs inside sandbox with `llm_query()` calling broker
+5. **Handle state** - Serialize/deserialize execution state between code blocks (typically via `dill`)
+
+See `rlm/environments/modal_repl.py` as the canonical reference implementation.
+
+### Broker Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/enqueue` | POST | Submit LLM request from sandbox code (blocks until response) |
+| `/pending` | GET | Get list of pending requests (called by host poller) |
+| `/respond` | POST | Submit response for a request ID (called by host poller) |
+| `/health` | GET | Health check |
+
+## Constants
+
+**File**: `rlm/environments/constants.py`
+
+Shared constants like safe builtins, default timeouts, and execution limits.
+
+## Testing Environments
+
+- Test `setup()` initializes correct globals
+- Test `execute_code()` returns proper `REPLResult` (stdout, stderr, success)
+- Test `load_context()` makes data accessible as `context` variable
+- Test `cleanup()` releases resources
+- Test `llm_query()` routing through LM Handler
+- Use `tests/mock_lm.py` for mock LM client
+
+## Learnings
+
+<!-- Claude: Add discoveries here as you work with environments -->

--- a/.claude/skills/python-pro/SKILL.md
+++ b/.claude/skills/python-pro/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: python-pro
+description: "Use when writing or reviewing Python code that requires expertise in type safety, async patterns, modern Python 3.11+ features, or testing patterns. Activates for type hints, async/await, dataclass design, Protocol patterns, and pytest best practices."
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Bash
+---
+
+# Python Pro
+
+Senior Python engineer specializing in modern Python 3.11+, type-safe, performant code for the RLM library.
+
+## When to Use
+
+- Designing type-safe interfaces for clients, environments, or core types
+- Writing async code (acompletion, async environments)
+- Implementing Protocol-based structural typing
+- Creating dataclasses and type hierarchies
+- Writing pytest tests with fixtures and parametrize
+- Reviewing Python patterns for correctness
+
+## Core Workflow
+
+1. **Analyze** existing code patterns in the codebase
+2. **Design** type-safe interfaces using Protocol, TypeVar, Generic
+3. **Implement** with full type annotations, idiomatic patterns
+4. **Test** with pytest, parametrize, and proper mocking
+5. **Validate** with `ruff check` and `ruff format`
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Type System | `references/type-system.md` | Generics, Protocol, TypeVar, type narrowing |
+| Async Patterns | `references/async-patterns.md` | asyncio, TaskGroup, async generators |
+| Testing | `references/testing.md` | pytest fixtures, parametrize, mocking |
+
+## Project Conventions
+
+These override generic Python best practices:
+
+- **Formatter**: `ruff` (not black). Line length 100. Target Python 3.11.
+- **Lint rules**: E, W, F, I, B, UP (see pyproject.toml)
+- **Type unions**: `X | None` (not `Optional[X]`)
+- **Type hints**: Required on all public function signatures
+- **Naming**: snake_case methods, PascalCase classes, UPPER_CASE constants
+- **No `_` prefix** for private methods unless explicitly requested
+- **Error handling**: Fail fast, fail loud. No defensive programming or silent fallbacks.
+- **Docstrings**: Keep concise and actionable. Not required on every function.
+
+## Constraints
+
+### MUST DO
+- Type hints for all public function signatures and class attributes
+- Use `X | None` instead of `Optional[X]`
+- Use `collections.abc` for abstract types (Sequence, Mapping, Callable)
+- Proper async/await -- never block in async context
+- Dataclasses for data containers, Protocol for structural typing
+- `ruff check` and `ruff format` must pass
+
+### MUST NOT DO
+- Skip type annotations on public APIs
+- Use mutable default arguments
+- Mix sync/async code improperly (use `asyncio.to_thread()` for blocking I/O)
+- Use bare `except:` without specific exception types
+- Add `# type: ignore` without strong justification
+- Hardcode secrets or API keys

--- a/.claude/skills/python-pro/references/async-patterns.md
+++ b/.claude/skills/python-pro/references/async-patterns.md
@@ -1,0 +1,137 @@
+# Async Patterns Reference
+
+## Basic Async/Await
+
+```python
+import asyncio
+
+async def fetch_data(url: str) -> dict:
+    await asyncio.sleep(1)  # Simulate I/O
+    return {"url": url, "data": "..."}
+
+async def main() -> None:
+    result = await fetch_data("https://api.example.com")
+    print(result)
+
+asyncio.run(main())
+```
+
+## Concurrent Operations with gather
+
+```python
+async def fetch_all(urls: list[str]) -> list[dict]:
+    tasks = [fetch_data(url) for url in urls]
+    return await asyncio.gather(*tasks)
+
+# With error handling
+results = await asyncio.gather(*tasks, return_exceptions=True)
+for result in results:
+    if isinstance(result, Exception):
+        print(f"Error: {result}")
+```
+
+## Task Groups (Python 3.11+)
+
+```python
+async def process_batch(items: list[str]) -> list[str]:
+    results: list[str] = []
+
+    async with asyncio.TaskGroup() as tg:
+        for item in items:
+            tg.create_task(process_item(item))
+
+    return results
+```
+
+## Semaphore for Rate Limiting
+
+```python
+sem = asyncio.Semaphore(5)  # Max 5 concurrent
+
+async def rate_limited_call(prompt: str) -> str:
+    async with sem:
+        return await api_call(prompt)
+
+# Use with batched operations
+async def batch_calls(prompts: list[str]) -> list[str]:
+    tasks = [rate_limited_call(p) for p in prompts]
+    return await asyncio.gather(*tasks)
+```
+
+## Async Context Managers
+
+```python
+from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator
+
+@asynccontextmanager
+async def managed_connection(url: str) -> AsyncIterator[Connection]:
+    conn = await connect(url)
+    try:
+        yield conn
+    finally:
+        await conn.close()
+```
+
+## Mixing Sync and Async
+
+```python
+# Run blocking I/O in thread pool
+async def read_large_file(path: str) -> str:
+    return await asyncio.to_thread(Path(path).read_text)
+
+# Bridge sync code calling async
+def sync_wrapper() -> str:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(async_function())
+    finally:
+        loop.close()
+```
+
+## Async Generators
+
+```python
+from collections.abc import AsyncIterator
+
+async def stream_results(query: str) -> AsyncIterator[dict]:
+    offset = 0
+    while True:
+        batch = await fetch_batch(query, offset)
+        if not batch:
+            break
+        for item in batch:
+            yield item
+        offset += len(batch)
+
+# Consume
+async for result in stream_results("SELECT *"):
+    process(result)
+```
+
+## Timeouts
+
+```python
+async def fetch_with_timeout(url: str, timeout: float = 5.0) -> dict:
+    async with asyncio.timeout(timeout):
+        return await fetch_data(url)
+```
+
+## Background Tasks
+
+```python
+class TaskManager:
+    def __init__(self) -> None:
+        self._tasks: set[asyncio.Task] = set()
+
+    def spawn(self, coro) -> asyncio.Task:
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def shutdown(self) -> None:
+        for task in self._tasks:
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+```

--- a/.claude/skills/python-pro/references/testing.md
+++ b/.claude/skills/python-pro/references/testing.md
@@ -1,0 +1,169 @@
+# Testing Reference
+
+## Basic Pytest
+
+```python
+import pytest
+
+def test_user_creation() -> None:
+    user = User(id=1, name="Alice")
+    assert user.name == "Alice"
+
+def test_validation_error() -> None:
+    with pytest.raises(ValueError, match="Invalid"):
+        validate_input("")
+
+class TestUserService:
+    def test_find(self) -> None:
+        service = UserService()
+        assert service.find(1) is not None
+```
+
+## Fixtures
+
+```python
+from collections.abc import Iterator
+
+@pytest.fixture
+def db() -> Iterator[Database]:
+    database = Database("test.db")
+    database.create_tables()
+    yield database
+    database.drop_tables()
+
+@pytest.fixture
+def sample_user() -> User:
+    return User(id=1, name="Test User")
+
+# Parametrized fixture
+@pytest.fixture(params=["local", "modal", "docker"])
+def environment_name(request: pytest.FixtureRequest) -> str:
+    return request.param
+```
+
+## Parametrize
+
+```python
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        ("hello", "HELLO"),
+        ("", ""),
+        ("123", "123"),
+    ],
+    ids=["basic", "empty", "numbers"]
+)
+def test_transform(input: str, expected: str) -> None:
+    assert transform(input) == expected
+
+# Multiple parameters
+@pytest.mark.parametrize("depth", [0, 1, 2])
+@pytest.mark.parametrize("backend", ["openai", "anthropic"])
+def test_routing(depth: int, backend: str) -> None:
+    assert route(depth, backend) is not None
+```
+
+## Mocking
+
+```python
+from unittest.mock import Mock, AsyncMock, patch, MagicMock
+
+# Basic mock
+def test_with_mock() -> None:
+    mock_client = Mock()
+    mock_client.get.return_value = {"status": "ok"}
+    service = Service(mock_client)
+    result = service.fetch()
+    mock_client.get.assert_called_once()
+
+# Patch decorator
+@patch("mymodule.external_call")
+def test_patched(mock_call: Mock) -> None:
+    mock_call.return_value = "mocked"
+    assert mymodule.do_thing() == "mocked"
+
+# Side effects for retry testing
+def test_retry() -> None:
+    mock_api = Mock()
+    mock_api.call.side_effect = [
+        ConnectionError("Failed"),
+        {"status": "ok"}
+    ]
+    result = retry_call(mock_api)
+    assert mock_api.call.call_count == 2
+
+# Async mock
+@pytest.mark.asyncio
+async def test_async() -> None:
+    mock_db = AsyncMock()
+    mock_db.fetch.return_value = {"id": 1}
+    result = await service.get(mock_db, 1)
+    mock_db.fetch.assert_awaited_once_with(1)
+```
+
+## Async Testing
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_async_fetch() -> None:
+    result = await fetch_data("test")
+    assert result is not None
+
+# Async fixture
+@pytest.fixture
+async def async_client() -> AsyncIterator[Client]:
+    client = Client()
+    await client.connect()
+    yield client
+    await client.disconnect()
+
+# Concurrent test
+@pytest.mark.asyncio
+async def test_concurrent() -> None:
+    results = await asyncio.gather(
+        fetch("a"), fetch("b"), fetch("c")
+    )
+    assert len(results) == 3
+```
+
+## Markers
+
+```python
+@pytest.mark.skip(reason="Not implemented")
+def test_future() -> None: ...
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires 3.11+")
+def test_new_feature() -> None: ...
+
+@pytest.mark.xfail(reason="Known bug #123")
+def test_known_bug() -> None: ...
+
+# Custom markers
+@pytest.mark.slow
+def test_slow() -> None: ...
+
+@pytest.mark.integration
+def test_integration() -> None: ...
+
+# Run: pytest -m "not slow"
+```
+
+## Factory Pattern
+
+```python
+@pytest.fixture
+def make_user():
+    created: list[User] = []
+
+    def _make(name: str = "Test", **kwargs) -> User:
+        user = User(name=name, **kwargs)
+        created.append(user)
+        return user
+
+    yield _make
+
+    for user in created:
+        user.cleanup()
+```

--- a/.claude/skills/python-pro/references/type-system.md
+++ b/.claude/skills/python-pro/references/type-system.md
@@ -1,0 +1,159 @@
+# Type System Reference
+
+## Basic Annotations
+
+```python
+from typing import Any
+from collections.abc import Sequence, Mapping
+
+# Use | for unions (Python 3.10+)
+def find_user(user_id: int | str) -> dict[str, Any] | None:
+    ...
+
+# Prefer collections.abc for abstract types
+def process_items(items: Sequence[str]) -> list[str]:
+    """Accepts list, tuple, or any sequence."""
+    return [item.upper() for item in items]
+
+def merge_configs(base: Mapping[str, int], override: dict[str, int]) -> dict[str, int]:
+    """Mapping for read-only, dict for mutable."""
+    return {**base, **override}
+```
+
+## Generic Types
+
+```python
+from typing import TypeVar, Generic
+from collections.abc import Sequence
+
+T = TypeVar('T')
+K = TypeVar('K')
+V = TypeVar('V')
+
+def first_element(items: Sequence[T]) -> T | None:
+    return items[0] if items else None
+
+class Cache(Generic[K, V]):
+    def __init__(self) -> None:
+        self._data: dict[K, V] = {}
+
+    def get(self, key: K) -> V | None:
+        return self._data.get(key)
+
+    def set(self, key: K, value: V) -> None:
+        self._data[key] = value
+```
+
+## Protocol for Structural Typing
+
+```python
+from typing import Protocol, runtime_checkable
+
+class Drawable(Protocol):
+    def draw(self) -> str: ...
+
+    @property
+    def color(self) -> str: ...
+
+# Circle implements Drawable without inheriting
+class Circle:
+    def draw(self) -> str:
+        return f"Drawing circle"
+
+    @property
+    def color(self) -> str:
+        return "red"
+
+def render(shape: Drawable) -> str:
+    return shape.draw()
+
+@runtime_checkable
+class Closeable(Protocol):
+    def close(self) -> None: ...
+```
+
+## Advanced Features
+
+```python
+from typing import Literal, TypeAlias, TypedDict, NotRequired, Self, overload
+
+# Literal types
+Mode = Literal["read", "write", "append"]
+
+# Type aliases
+JsonDict: TypeAlias = dict[str, Any]
+
+# TypedDict
+class UserDict(TypedDict):
+    id: int
+    name: str
+    email: NotRequired[str]
+
+# Self type for method chaining
+class Builder:
+    def add(self, n: int) -> Self:
+        self._value += n
+        return self
+
+# Overload for different signatures
+@overload
+def process(data: str) -> str: ...
+@overload
+def process(data: int) -> int: ...
+def process(data: str | int) -> str | int:
+    if isinstance(data, str):
+        return data.upper()
+    return data * 2
+```
+
+## Callable Types
+
+```python
+from collections.abc import Callable
+from typing import ParamSpec, Concatenate
+
+P = ParamSpec('P')
+R = TypeVar('R')
+
+# Preserve function signatures in decorators
+def logging_decorator(func: Callable[P, R]) -> Callable[P, R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        print(f"Calling {func.__name__}")
+        return func(*args, **kwargs)
+    return wrapper
+```
+
+## Type Narrowing
+
+```python
+from typing import assert_never
+
+def handle_mode(mode: Literal["read", "write"]) -> str:
+    if mode == "read":
+        return "Reading"
+    elif mode == "write":
+        return "Writing"
+    else:
+        assert_never(mode)  # Exhaustiveness check
+```
+
+## Common Patterns in RLM
+
+```python
+# Result type for operations that can fail
+@dataclass
+class Success(Generic[T]):
+    value: T
+
+@dataclass
+class Error:
+    message: str
+
+Result = Success[T] | Error
+
+# Protocol for LM clients
+class LMProtocol(Protocol):
+    def completion(self, prompt: str | list[dict[str, Any]], model: str | None = None) -> str: ...
+    async def acompletion(self, prompt: str | list[dict[str, Any]], model: str | None = None) -> str: ...
+    def get_usage_summary(self) -> UsageSummary: ...
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,3 +318,48 @@ When building a new isolated environment (e.g., for a new cloud provider):
 
 See `rlm/environments/modal_repl.py` as the canonical reference implementation.
 
+## Claude Code Skills & Agents
+
+### Domain Context Loading
+
+Load focused domain knowledge before working on specific areas:
+
+```
+/domain core           # RLM completion flow, REPL, FINAL_VAR, context reduction
+/domain environments   # Environment development, base classes, broker pattern
+/domain clients        # LM client development, BaseLM, usage tracking
+/domain architecture   # Socket protocol, HTTP broker, comms
+/domain                # Auto-detect from conversation context
+```
+
+Domain docs are living documents in `.claude/skills/domain/docs/`. Add discoveries to the Learnings section.
+
+### Specialized Skills
+
+| Skill | When to Use |
+|-------|-------------|
+| `/domain` | Load domain context before working on specific areas |
+| `/python-pro` | Python 3.11+ type safety, async patterns, pytest |
+| `/architecture-designer` | Design decisions, ADRs, trade-off evaluation |
+
+### Agents
+
+| Agent | Purpose |
+|-------|---------|
+| `code-reviewer` | Review PR diffs for correctness, security, RLM patterns |
+| `test-writer` | Design and write tests using project mock patterns |
+
+### Verification Loop
+
+Always verify changes before committing:
+
+```bash
+uv run ruff check --fix .
+uv run ruff format .
+uv run pytest
+```
+
+### Auto-Formatting Hook
+
+The `.claude/settings.json` runs `ruff check --fix` and `ruff format` automatically on every Python file edit/write.
+


### PR DESCRIPTION
## Summary
- Add `.claude/` directory with Claude Code development tooling adapted from rlm-service patterns
- Add domain context skill with 4 library-specific domains (core, environments, clients, architecture)
- Add code-reviewer and test-writer agents tailored for the RLM library
- Add Python Pro skill with type system, async patterns, and testing references
- Add Architecture Designer skill with patterns and ADR templates
- Update AGENTS.md with skills/agents reference section

## Test plan
- [ ] Verify skills load correctly with `/domain`, `/python-pro`, `/architecture-designer`
- [ ] Verify agents work via Task tool (code-reviewer, test-writer)
- [ ] Verify ruff auto-format hook triggers on Python file edits
- [ ] Confirm settings.json permissions cover standard dev workflow