### PR TITLE
fix: FINAL() callable in REPL; parser ignores FINAL/FINAL_VAR inside code fences

### DIFF
--- a/rlm/environments/base_env.py
+++ b/rlm/environments/base_env.py
@@ -16,6 +16,7 @@ RESERVED_TOOL_NAMES: frozenset[str] = frozenset(
         "llm_query_batched",
         "rlm_query",
         "rlm_query_batched",
+        "FINAL",
         "FINAL_VAR",
         "SHOW_VARS",
         "context",

--- a/rlm/environments/local_repl.py
+++ b/rlm/environments/local_repl.py
@@ -188,6 +188,7 @@ class LocalREPL(NonIsolatedEnv):
         self._last_final_answer: str | None = None
 
         # Add helper functions
+        self.globals["FINAL"] = self._final
         self.globals["FINAL_VAR"] = self._final_var
         self.globals["SHOW_VARS"] = self._show_vars
         self.globals["llm_query"] = self._llm_query
@@ -204,6 +205,12 @@ class LocalREPL(NonIsolatedEnv):
             else:
                 # For non-callable values (constants, data), add to locals
                 self.locals[name] = value
+
+    def _final(self, value: Any) -> str:
+        """Store and return a direct final value (compat with models calling FINAL in REPL)."""
+        answer = str(value)
+        self._last_final_answer = answer
+        return answer
 
     def _final_var(self, variable_name: str | Any) -> str:
         """Return the value of a variable as a final answer for the main model, or stringify a direct value."""
@@ -468,6 +475,8 @@ class LocalREPL(NonIsolatedEnv):
                 self.globals["rlm_query"] = self._rlm_query
             elif name == "rlm_query_batched":
                 self.globals["rlm_query_batched"] = self._rlm_query_batched
+            elif name == "FINAL":
+                self.globals["FINAL"] = self._final
             elif name == "FINAL_VAR":
                 self.globals["FINAL_VAR"] = self._final_var
             elif name == "SHOW_VARS":

--- a/rlm/utils/parsing.py
+++ b/rlm/utils/parsing.py
@@ -40,9 +40,13 @@ def find_final_answer(text: str, environment: "BaseEnv | None" = None) -> str | 
     Returns:
         The final answer string, or None if no final answer pattern is found
     """
+    # Remove fenced code blocks first so FINAL()/FINAL_VAR() inside ```repl``` code
+    # does not get parsed as a terminal answer.
+    text_no_code = re.sub(r"```[\s\S]*?```", "", text)
+
     # Check for FINAL_VAR pattern first - must be at start of line
     final_var_pattern = r"^\s*FINAL_VAR\((.*?)\)"
-    match = re.search(final_var_pattern, text, re.MULTILINE | re.DOTALL)
+    match = re.search(final_var_pattern, text_no_code, re.MULTILINE | re.DOTALL)
     if match:
         variable_name = match.group(1).strip().strip('"').strip("'")
         if environment is not None:
@@ -63,7 +67,7 @@ def find_final_answer(text: str, environment: "BaseEnv | None" = None) -> str | 
     # Check for FINAL pattern - must be at start of line
     # Use greedy matching to capture content with nested parentheses
     final_pattern = r"^\s*FINAL\((.*)\)\s*$"
-    match = re.search(final_pattern, text, re.MULTILINE | re.DOTALL)
+    match = re.search(final_pattern, text_no_code, re.MULTILINE | re.DOTALL)
     if match:
         return match.group(1).strip()
 


### PR DESCRIPTION
## Problem

Two bugs caused the RLM to silently return wrong answers when a model chose to call `FINAL()` or `FINAL_VAR()` inside a ` ```repl ``` ` code block — a natural pattern given the system prompt examples.

### Bug 1 – Parser (`utils/parsing.py`)

`find_final_answer()` ran its `FINAL(...)` / `FINAL_VAR(...)` regex over the **raw** assistant response, including inside fenced code blocks. So when the model wrote:

\`\`\`repl
FINAL(final_answer)
\`\`\`

the parser matched `FINAL(final_answer)` and returned the **literal string** `"final_answer"` as the completion response instead of the variable's value. No error was raised — the RLM just silently returned a wrong string.

### Bug 2 – Runtime (`environments/local_repl.py`, `environments/base_env.py`)

The system prompt offers `FINAL(value)` as **option 1** for submitting a final answer:

> 1. Use `FINAL(your final answer here)` to provide the answer directly

But `FINAL` was **never injected into the REPL globals** — only `FINAL_VAR` was. So when the model called `FINAL(x)` inside a repl block it got a `NameError`, and the REPL stderr was shown to the model, wasting an iteration. The only reason the run didn't always fail is that the *parser* still picked up `FINAL(...)` from the response text — leading to bug 1 above.

## Fix

**`utils/parsing.py`** — strip all fenced code blocks from the response before running the `FINAL`/`FINAL_VAR` regex. This ensures only prose-level `FINAL(...)` signals termination.

**`environments/local_repl.py`** — add `_final(value)` method (mirrors `_final_var` for direct values), inject it as `globals["FINAL"]`, and restore it in `_restore_scaffold()`.

**`environments/base_env.py`** — add `"FINAL"` to `RESERVED_TOOL_NAMES` so it can't be overwritten by user code.

## Tests added (`tests/test_parsing.py`)

| Test | Covers |
|---|---|
| `test_final_inside_repl_code_block_not_parsed_as_terminal` | Parser ignores `FINAL()` in code fence |
| `test_final_var_inside_repl_code_block_not_parsed_as_terminal` | Parser ignores `FINAL_VAR()` in code fence |
| `test_final_in_prose_still_works_alongside_repl_block` | Prose `FINAL()` still terminates after code fence |
| `test_final_callable_in_repl_environment` | `FINAL(x)` callable in REPL sets `final_answer` |

All 16 `TestFindFinalAnswer` tests pass.

## How to reproduce (before fix)

```python
from rlm import RLM
rlm = RLM(backend="openai", backend_kwargs={"model_name": "gpt-4o-mini"}, environment="local", max_depth=1)
result = rlm.completion("Compute the sum of integers from 1 to 10 and print only the number.")
print(result.response)  # prints "final_answer" instead of "55"
```

Made with [Cursor](https://cursor.com)