### PR TITLE
fix: move pytest from runtime dependencies to test extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "google-genai>=1.56.0",
     "openai>=2.14.0",
     "portkey-ai>=2.1.0",
-    "pytest>=9.0.2",
     "python-dotenv>=1.2.1",
     "requests>=2.32.5",
     "rich>=13.0.0",


### PR DESCRIPTION
## Problem

`pytest>=9.0.2` is listed in `[project.dependencies]`, so it gets installed for all users even though it's only needed for testing. It's already correctly listed under `[project.optional-dependencies.test]`.

Fixes #93

## Changes

Remove `pytest>=9.0.2` from `[project.dependencies]` in `pyproject.toml`. The `[project.optional-dependencies.test]` section already includes `pytest>=8.0.0` for development use.

## Impact

Users installing via `pip install rlms` will no longer pull in pytest and its transitive dependencies unnecessarily. Developers can still install test deps via `pip install rlms[test]`.