### PR TITLE
fix incorrect numbering of custom tools section in system prompt

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -371,7 +371,7 @@ rlm = RLM(
 
 The descriptions are automatically added to the system prompt:
 ```
-6. Custom tools and data available in the REPL:
+**Custom tools and data available in the REPL:**
 - `fetch_weather`: Fetch current weather data for a city name
 - `calculate_shipping`: Calculate shipping cost given weight (kg) and distance (km)
 - `API_KEY`: API key for the weather service

--- a/rlm/utils/prompts.py
+++ b/rlm/utils/prompts.py
@@ -147,7 +147,7 @@ def build_rlm_system_prompt(
     tools_formatted = format_tools_for_prompt(custom_tools)
     if tools_formatted:
         custom_tools_section = (
-            f"\n6. Custom tools and data available in the REPL:\n{tools_formatted}"
+            f"\n**Custom tools and data available in the REPL:**\n{tools_formatted}"
         )
     else:
         custom_tools_section = ""


### PR DESCRIPTION
The custom tools section was hardcoded as item "6." but the numbered list already has 7 items, causing a duplicate. Use bold markdown header instead to decouple it from the numbered list.