### PR TITLE
fix: replace 15 bare excepts with except Exception in REPL environments

### DIFF
--- a/rlm/environments/daytona_repl.py
+++ b/rlm/environments/daytona_repl.py
@@ -266,7 +266,7 @@ def load_state():
         try:
             with open(STATE_FILE, "rb") as f:
                 return dill.load(f)
-        except:
+        except Exception:
             pass
     return {{}}
 
@@ -278,7 +278,7 @@ def save_state(state):
         try:
             dill.dumps(v)
             clean_state[k] = v
-        except:
+        except Exception:
             pass
     with open(STATE_FILE, "wb") as f:
         dill.dump(clean_state, f)
@@ -290,7 +290,7 @@ def serialize_locals(state):
             continue
         try:
             result[k] = repr(v)
-        except:
+        except Exception:
             result[k] = f"<{{type(v).__name__}}>"
     return result
 

--- a/rlm/environments/docker_repl.py
+++ b/rlm/environments/docker_repl.py
@@ -124,7 +124,7 @@ def load_state():
         try:
             with open(STATE, "rb") as f:
                 return dill.load(f)
-        except:
+        except Exception:
             pass
     return {{}}
 
@@ -133,7 +133,7 @@ def save_state(s):
     for k in list(clean.keys()):
         try:
             dill.dumps(clean[k])
-        except:
+        except Exception:
             del clean[k]
     with open(STATE, "wb") as f:
         dill.dump(clean, f)
@@ -168,7 +168,7 @@ try:
     for k, v in combined.items():
         if k not in _globals and not k.startswith("_"):
             _locals[k] = v
-except:
+except Exception:
     traceback.print_exc(file=stderr_buf)
 finally:
     sys.stdout, sys.stderr = old_stdout, old_stderr

--- a/rlm/environments/e2b_repl.py
+++ b/rlm/environments/e2b_repl.py
@@ -173,7 +173,7 @@ def load_state():
         try:
             with open(STATE_FILE, "rb") as f:
                 return dill.load(f)
-        except:
+        except Exception:
             pass
     return {{}}
 
@@ -185,7 +185,7 @@ def save_state(state):
         try:
             dill.dumps(v)
             clean_state[k] = v
-        except:
+        except Exception:
             pass
     with open(STATE_FILE, "wb") as f:
         dill.dump(clean_state, f)
@@ -197,7 +197,7 @@ def serialize_locals(state):
             continue
         try:
             result[k] = repr(v)
-        except:
+        except Exception:
             result[k] = f"<{{type(v).__name__}}>"
     return result
 

--- a/rlm/environments/modal_repl.py
+++ b/rlm/environments/modal_repl.py
@@ -183,7 +183,7 @@ def load_state():
         try:
             with open(STATE_FILE, "rb") as f:
                 return dill.load(f)
-        except:
+        except Exception:
             pass
     return {{}}
 
@@ -195,7 +195,7 @@ def save_state(state):
         try:
             dill.dumps(v)
             clean_state[k] = v
-        except:
+        except Exception:
             pass
     with open(STATE_FILE, "wb") as f:
         dill.dump(clean_state, f)
@@ -207,7 +207,7 @@ def serialize_locals(state):
             continue
         try:
             result[k] = repr(v)
-        except:
+        except Exception:
             result[k] = f"<{{type(v).__name__}}>"
     return result
 

--- a/rlm/environments/prime_repl.py
+++ b/rlm/environments/prime_repl.py
@@ -182,7 +182,7 @@ def load_state():
         try:
             with open(STATE_FILE, "rb") as f:
                 return dill.load(f)
-        except:
+        except Exception:
             pass
     return {{}}
 
@@ -194,7 +194,7 @@ def save_state(state):
         try:
             dill.dumps(v)
             clean_state[k] = v
-        except:
+        except Exception:
             pass
     with open(STATE_FILE, "wb") as f:
         dill.dump(clean_state, f)
@@ -206,7 +206,7 @@ def serialize_locals(state):
             continue
         try:
             result[k] = repr(v)
-        except:
+        except Exception:
             result[k] = f"<{{type(v).__name__}}>"
     return result
 


### PR DESCRIPTION
## Summary

Replace 15 bare `except:` clauses with `except Exception:` across 5 REPL environment modules.

## Why

Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, which can mask real errors and prevent clean process termination. `except Exception:` preserves the intended error-suppression behavior (state serialization, repr fallback, etc.) while allowing system-level exceptions to propagate normally.

## Changes

All changes are in `rlm/environments/` — no core files touched:
- `daytona_repl.py` (3 sites): state load/save/serialize
- `docker_repl.py` (3 sites): state load/save/serialize + exec error handling  
- `e2b_repl.py` (3 sites): state load/save/serialize
- `modal_repl.py` (3 sites): state load/save/serialize
- `prime_repl.py` (3 sites): state load/save/serialize

All 5 files follow the same pattern — the bare excepts guard against serialization failures (dill/repr), which should only raise standard exceptions.