### PR TITLE
Add Claude Code CLI client and unit tests

### DIFF
--- a/rlm/clients/__init__.py
+++ b/rlm/clients/__init__.py
@@ -57,7 +57,11 @@ def get_client(
         from rlm.clients.azure_openai import AzureOpenAIClient
 
         return AzureOpenAIClient(**backend_kwargs)
+    elif backend == "claude_cli":
+        from rlm.clients.claude_cli import ClaudeCodeCLI
+
+        return ClaudeCodeCLI(**backend_kwargs)
     else:
         raise ValueError(
-            f"Unknown backend: {backend}. Supported backends: ['openai', 'vllm', 'portkey', 'openrouter', 'litellm', 'anthropic', 'azure_openai', 'gemini', 'vercel']"
+            f"Unknown backend: {backend}. Supported backends: ['openai', 'vllm', 'portkey', 'openrouter', 'litellm', 'anthropic', 'azure_openai', 'gemini', 'vercel', 'claude_cli']"
         )

--- a/rlm/clients/claude_cli.py
+++ b/rlm/clients/claude_cli.py
@@ -1,0 +1,192 @@
+import asyncio
+import os
+import shutil
+import subprocess
+from collections import defaultdict
+from typing import Any
+
+from rlm.clients.base_lm import BaseLM
+from rlm.core.types import ModelUsageSummary, UsageSummary
+
+# Characters-per-token estimate (CLI doesn't return usage data)
+_CHARS_PER_TOKEN = 4
+
+
+class ClaudeCodeCLI(BaseLM):
+    """
+    LM Client that shells out to the ``claude`` CLI (``claude --print``)
+    instead of calling an HTTP API.
+
+    Designed for use inside cc-dirigent's RLM integration so that the full
+    RLM REPL loop can run without any API keys — Claude Code handles auth.
+
+    Model names use CLI aliases: ``sonnet``, ``opus``, ``haiku``.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "sonnet",
+        max_budget_usd: float | None = None,
+        permission_mode: str = "bypassPermissions",
+        **kwargs,
+    ):
+        super().__init__(model_name=model_name, **kwargs)
+        self.model_name = model_name
+        self.max_budget_usd = max_budget_usd
+        self.permission_mode = permission_mode
+
+        # Verify ``claude`` is on PATH
+        if not shutil.which("claude"):
+            raise FileNotFoundError(
+                "claude CLI not found on PATH. Install Claude Code first: "
+                "https://docs.anthropic.com/en/docs/claude-code"
+            )
+
+        # Per-model usage tracking (estimated)
+        self.model_call_counts: dict[str, int] = defaultdict(int)
+        self.model_input_tokens: dict[str, int] = defaultdict(int)
+        self.model_output_tokens: dict[str, int] = defaultdict(int)
+
+        self.last_prompt_tokens: int = 0
+        self.last_completion_tokens: int = 0
+
+        # Build a clean env that allows nested claude invocations.
+        # CLAUDECODE env var blocks nested sessions — strip it.
+        self._env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    # ── helpers ────────────────────────────────────────────
+
+    def _build_cmd(self, system: str | None, model: str | None) -> list[str]:
+        """Build the ``claude`` CLI argument list."""
+        model = model or self.model_name
+        cmd = [
+            "claude",
+            "--print",
+            "--model", model,
+            "--no-session-persistence",
+            "--permission-mode", self.permission_mode,
+        ]
+        if system:
+            cmd.extend(["--system-prompt", system])
+        if self.max_budget_usd is not None:
+            cmd.extend(["--max-budget-usd", str(self.max_budget_usd)])
+        return cmd
+
+    def _prepare_prompt(
+        self, prompt: str | list[dict[str, Any]]
+    ) -> tuple[str, str | None]:
+        """
+        Convert a prompt (string or message list) into ``(user_text, system)``
+        for piping to ``claude --print``.
+
+        Mirrors ``AnthropicClient._prepare_messages`` — system messages are
+        extracted and passed via ``--system-prompt``.
+        """
+        system: str | None = None
+
+        if isinstance(prompt, str):
+            return prompt, None
+
+        if isinstance(prompt, list) and all(isinstance(m, dict) for m in prompt):
+            parts: list[str] = []
+            for msg in prompt:
+                role = msg.get("role", "")
+                content = msg.get("content", "")
+                if role == "system":
+                    system = content
+                else:
+                    parts.append(str(content))
+            return "\n\n".join(parts), system
+
+        raise ValueError(f"Invalid prompt type: {type(prompt)}")
+
+    @staticmethod
+    def _estimate_tokens(text: str) -> int:
+        return (len(text) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN
+
+    def _track_usage(self, prompt_text: str, response_text: str, model: str) -> None:
+        input_tokens = self._estimate_tokens(prompt_text)
+        output_tokens = self._estimate_tokens(response_text)
+
+        self.model_call_counts[model] += 1
+        self.model_input_tokens[model] += input_tokens
+        self.model_output_tokens[model] += output_tokens
+
+        self.last_prompt_tokens = input_tokens
+        self.last_completion_tokens = output_tokens
+
+    # ── BaseLM interface ──────────────────────────────────
+
+    def completion(
+        self, prompt: str | list[dict[str, Any]], model: str | None = None
+    ) -> str:
+        user_text, system = self._prepare_prompt(prompt)
+        model = model or self.model_name
+        cmd = self._build_cmd(system, model)
+
+        # Uses subprocess.run with explicit argument list (no shell=True)
+        # to prevent command injection. User input is passed via stdin only.
+        result = subprocess.run(
+            cmd,
+            input=user_text,
+            capture_output=True,
+            text=True,
+            timeout=self.timeout,
+            env=self._env,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"claude CLI exited with code {result.returncode}: {result.stderr.strip()}"
+            )
+
+        response = result.stdout.strip()
+        self._track_usage(user_text, response, model)
+        return response
+
+    async def acompletion(
+        self, prompt: str | list[dict[str, Any]], model: str | None = None
+    ) -> str:
+        user_text, system = self._prepare_prompt(prompt)
+        model = model or self.model_name
+        cmd = self._build_cmd(system, model)
+
+        # Uses asyncio.create_subprocess_exec (not _shell) with explicit
+        # argument list to prevent command injection. Input via stdin only.
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=self._env,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(input=user_text.encode()),
+            timeout=self.timeout,
+        )
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"claude CLI exited with code {proc.returncode}: {stderr.decode().strip()}"
+            )
+
+        response = stdout.decode().strip()
+        self._track_usage(user_text, response, model)
+        return response
+
+    def get_usage_summary(self) -> UsageSummary:
+        model_summaries = {}
+        for model in self.model_call_counts:
+            model_summaries[model] = ModelUsageSummary(
+                total_calls=self.model_call_counts[model],
+                total_input_tokens=self.model_input_tokens[model],
+                total_output_tokens=self.model_output_tokens[model],
+            )
+        return UsageSummary(model_usage_summaries=model_summaries)
+
+    def get_last_usage(self) -> ModelUsageSummary:
+        return ModelUsageSummary(
+            total_calls=1,
+            total_input_tokens=self.last_prompt_tokens,
+            total_output_tokens=self.last_completion_tokens,
+        )

--- a/rlm/core/types.py
+++ b/rlm/core/types.py
@@ -12,6 +12,7 @@ ClientBackend = Literal[
     "anthropic",
     "azure_openai",
     "gemini",
+    "claude_cli",
 ]
 EnvironmentType = Literal["local", "docker", "modal", "prime", "daytona", "e2b"]
 

--- a/rlm/utils/token_utils.py
+++ b/rlm/utils/token_utils.py
@@ -64,6 +64,10 @@ MODEL_CONTEXT_LIMITS: dict[str, int] = {
     "glm-4-9b": 1_000_000,
     "glm-4": 128_000,
     "glm": 128_000,
+    # Claude CLI aliases (used by claude_cli backend)
+    "sonnet": 200_000,
+    "opus": 200_000,
+    "haiku": 200_000,
 }
 
 

--- a/tests/clients/test_claude_cli.py
+++ b/tests/clients/test_claude_cli.py
@@ -1,0 +1,288 @@
+"""Tests for ClaudeCodeCLI client."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rlm.core.types import ModelUsageSummary, UsageSummary
+
+
+@pytest.fixture
+def cli_client():
+    """Create a ClaudeCodeCLI instance with mocked shutil.which."""
+    with patch("rlm.clients.claude_cli.shutil.which", return_value="/usr/local/bin/claude"):
+        from rlm.clients.claude_cli import ClaudeCodeCLI
+
+        return ClaudeCodeCLI(model_name="sonnet")
+
+
+@pytest.fixture
+def cli_client_custom():
+    """Create a ClaudeCodeCLI with custom options."""
+    with patch("rlm.clients.claude_cli.shutil.which", return_value="/usr/local/bin/claude"):
+        from rlm.clients.claude_cli import ClaudeCodeCLI
+
+        return ClaudeCodeCLI(
+            model_name="opus",
+            max_budget_usd=5.0,
+            permission_mode="plan",
+        )
+
+
+class TestInit:
+    def test_defaults(self, cli_client):
+        assert cli_client.model_name == "sonnet"
+        assert cli_client.max_budget_usd is None
+        assert cli_client.permission_mode == "bypassPermissions"
+
+    def test_custom_options(self, cli_client_custom):
+        assert cli_client_custom.model_name == "opus"
+        assert cli_client_custom.max_budget_usd == 5.0
+        assert cli_client_custom.permission_mode == "plan"
+
+    def test_missing_cli_raises(self):
+        with patch("rlm.clients.claude_cli.shutil.which", return_value=None):
+            from rlm.clients.claude_cli import ClaudeCodeCLI
+
+            with pytest.raises(FileNotFoundError, match="claude CLI not found"):
+                ClaudeCodeCLI()
+
+    def test_env_strips_claudecode(self, cli_client):
+        assert "CLAUDECODE" not in cli_client._env
+
+
+class TestBuildCmd:
+    def test_basic_cmd(self, cli_client):
+        cmd = cli_client._build_cmd(system=None, model="sonnet")
+        assert cmd == [
+            "claude", "--print",
+            "--model", "sonnet",
+            "--no-session-persistence",
+            "--permission-mode", "bypassPermissions",
+        ]
+
+    def test_with_system_prompt(self, cli_client):
+        cmd = cli_client._build_cmd(system="You are helpful.", model="sonnet")
+        assert "--system-prompt" in cmd
+        idx = cmd.index("--system-prompt")
+        assert cmd[idx + 1] == "You are helpful."
+
+    def test_with_budget(self, cli_client_custom):
+        cmd = cli_client_custom._build_cmd(system=None, model="opus")
+        assert "--max-budget-usd" in cmd
+        idx = cmd.index("--max-budget-usd")
+        assert cmd[idx + 1] == "5.0"
+
+    def test_model_override(self, cli_client):
+        cmd = cli_client._build_cmd(system=None, model="haiku")
+        assert cmd[cmd.index("--model") + 1] == "haiku"
+
+
+class TestPreparePrompt:
+    def test_string_prompt(self, cli_client):
+        text, system = cli_client._prepare_prompt("Hello")
+        assert text == "Hello"
+        assert system is None
+
+    def test_message_list_no_system(self, cli_client):
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+        ]
+        text, system = cli_client._prepare_prompt(messages)
+        assert text == "Hi\n\nHello"
+        assert system is None
+
+    def test_message_list_with_system(self, cli_client):
+        messages = [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Hi"},
+        ]
+        text, system = cli_client._prepare_prompt(messages)
+        assert text == "Hi"
+        assert system == "Be concise."
+
+    def test_invalid_prompt_type(self, cli_client):
+        with pytest.raises(ValueError, match="Invalid prompt type"):
+            cli_client._prepare_prompt(12345)
+
+
+class TestEstimateTokens:
+    def test_basic_estimate(self):
+        from rlm.clients.claude_cli import ClaudeCodeCLI
+
+        assert ClaudeCodeCLI._estimate_tokens("abcd") == 1  # 4 chars / 4
+        assert ClaudeCodeCLI._estimate_tokens("abcde") == 2  # 5 chars -> ceil(5/4)
+        assert ClaudeCodeCLI._estimate_tokens("") == 0
+
+    def test_longer_text(self):
+        from rlm.clients.claude_cli import ClaudeCodeCLI
+
+        text = "a" * 100
+        assert ClaudeCodeCLI._estimate_tokens(text) == 25
+
+
+class TestCompletion:
+    def test_successful_completion(self, cli_client):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Hello, world!\n"
+        mock_result.stderr = ""
+
+        with patch("rlm.clients.claude_cli.subprocess.run", return_value=mock_result) as mock_run:
+            result = cli_client.completion("Say hello")
+
+        assert result == "Hello, world!"
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["input"] == "Say hello"
+        assert call_kwargs["capture_output"] is True
+        assert call_kwargs["text"] is True
+        assert call_kwargs["timeout"] == cli_client.timeout
+
+    def test_completion_with_model_override(self, cli_client):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "response"
+        mock_result.stderr = ""
+
+        with patch("rlm.clients.claude_cli.subprocess.run", return_value=mock_result) as mock_run:
+            cli_client.completion("test", model="opus")
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[cmd.index("--model") + 1] == "opus"
+
+    def test_completion_nonzero_exit(self, cli_client):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "Error: something went wrong"
+
+        with patch("rlm.clients.claude_cli.subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="claude CLI exited with code 1"):
+                cli_client.completion("test")
+
+    def test_completion_tracks_usage(self, cli_client):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "response text"
+        mock_result.stderr = ""
+
+        with patch("rlm.clients.claude_cli.subprocess.run", return_value=mock_result):
+            cli_client.completion("input text")
+
+        assert cli_client.model_call_counts["sonnet"] == 1
+        assert cli_client.model_input_tokens["sonnet"] > 0
+        assert cli_client.model_output_tokens["sonnet"] > 0
+
+    def test_completion_with_message_list(self, cli_client):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "ok"
+        mock_result.stderr = ""
+
+        messages = [
+            {"role": "system", "content": "Be brief."},
+            {"role": "user", "content": "Hi"},
+        ]
+
+        with patch("rlm.clients.claude_cli.subprocess.run", return_value=mock_result) as mock_run:
+            cli_client.completion(messages)
+
+        cmd = mock_run.call_args[0][0]
+        assert "--system-prompt" in cmd
+        assert mock_run.call_args[1]["input"] == "Hi"
+
+
+class TestAcompletion:
+    def test_successful_acompletion(self, cli_client):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"Hello async!", b""))
+
+        with patch("rlm.clients.claude_cli.asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
+            result = asyncio.run(cli_client.acompletion("Say hello"))
+
+        assert result == "Hello async!"
+
+    def test_acompletion_nonzero_exit(self, cli_client):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"async error"))
+
+        with patch("rlm.clients.claude_cli.asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
+            with pytest.raises(RuntimeError, match="claude CLI exited with code 1"):
+                asyncio.run(cli_client.acompletion("test"))
+
+    def test_acompletion_tracks_usage(self, cli_client):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"async response", b""))
+
+        with patch("rlm.clients.claude_cli.asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
+            asyncio.run(cli_client.acompletion("async input"))
+
+        assert cli_client.model_call_counts["sonnet"] == 1
+
+
+class TestUsageSummary:
+    def test_get_usage_summary_empty(self, cli_client):
+        summary = cli_client.get_usage_summary()
+        assert isinstance(summary, UsageSummary)
+        assert summary.model_usage_summaries == {}
+
+    def test_get_usage_summary_after_calls(self, cli_client):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "resp"
+        mock_result.stderr = ""
+
+        with patch("rlm.clients.claude_cli.subprocess.run", return_value=mock_result):
+            cli_client.completion("a]")
+            cli_client.completion("b")
+
+        summary = cli_client.get_usage_summary()
+        assert "sonnet" in summary.model_usage_summaries
+        assert summary.model_usage_summaries["sonnet"].total_calls == 2
+
+    def test_get_last_usage(self, cli_client):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "response"
+        mock_result.stderr = ""
+
+        with patch("rlm.clients.claude_cli.subprocess.run", return_value=mock_result):
+            cli_client.completion("input")
+
+        last = cli_client.get_last_usage()
+        assert isinstance(last, ModelUsageSummary)
+        assert last.total_calls == 1
+        assert last.total_input_tokens > 0
+        assert last.total_output_tokens > 0
+
+    def test_multi_model_tracking(self, cli_client):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "ok"
+        mock_result.stderr = ""
+
+        with patch("rlm.clients.claude_cli.subprocess.run", return_value=mock_result):
+            cli_client.completion("a", model="sonnet")
+            cli_client.completion("b", model="opus")
+
+        summary = cli_client.get_usage_summary()
+        assert "sonnet" in summary.model_usage_summaries
+        assert "opus" in summary.model_usage_summaries
+        assert summary.model_usage_summaries["sonnet"].total_calls == 1
+        assert summary.model_usage_summaries["opus"].total_calls == 1
+
+
+class TestGetClient:
+    def test_get_client_claude_cli(self):
+        with patch("rlm.clients.claude_cli.shutil.which", return_value="/usr/local/bin/claude"):
+            from rlm.clients import get_client
+
+            client = get_client("claude_cli", {})
+            from rlm.clients.claude_cli import ClaudeCodeCLI
+
+            assert isinstance(client, ClaudeCodeCLI)


### PR DESCRIPTION
## Summary
- Add `ClaudeCodeCLI` backend that shells out to `claude --print` for API-key-free LLM usage
- Register `claude_cli` in `ClientBackend` type, `get_client` router, and token context limits
- Add 27 unit tests covering init, command building, prompt preparation, sync/async completion, usage tracking, and `get_client` integration

## Test plan
- [x] All 27 tests pass (`uv run pytest tests/clients/test_claude_cli.py -v`)
- [x] Full test suite passes (281 passed, 10 skipped, 0 failures)
- [x] Manual smoke test with `claude` CLI — returns correct response with usage tracking