### PR TITLE
Fail fast on oversized plain LM prompts and clarify llm_query semantics

### DIFF
--- a/docs/api/rlm.md
+++ b/docs/api/rlm.md
@@ -546,9 +546,9 @@ The following functions are available to model-generated code inside the REPL:
 
 | Function | Description |
 |:---------|:------------|
-| `llm_query(prompt, model=None)` | Single plain LM completion. Fast, no REPL or iteration. |
+| `llm_query(prompt, model=None)` | Single plain LM completion. Fast, no REPL or iteration. Use when the prompt already fits the target model's context window. |
 | `llm_query_batched(prompts, model=None)` | Multiple plain LM completions concurrently. |
-| `rlm_query(prompt, model=None)` | Spawn a child RLM with its own REPL for deeper thinking. Falls back to `llm_query` at max depth. |
+| `rlm_query(prompt, model=None)` | Spawn a child RLM with its own REPL for deeper thinking, or to offload a large subtask where recursive subcalls are available. Falls back to `llm_query` at max depth. |
 | `rlm_query_batched(prompts, model=None)` | Spawn multiple child RLMs. Falls back to `llm_query_batched` at max depth. |
 | `FINAL_VAR(variable_name)` | Return a REPL variable as the final answer. |
 | `SHOW_VARS()` | List all user-created variables in the REPL. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,7 +168,8 @@ They have very different behaviors:
 ### `llm_query(prompt, model=None)` — Plain LM call
 
 Always makes a single, direct LM completion. No REPL, no iteration — just
-prompt in, text out. Fast and lightweight.
+prompt in, text out. Fast and lightweight, but the prompt still has to fit
+the selected model's context window.
 
 ```
 Model code: answer = llm_query("Summarize this text: ...")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -173,8 +173,8 @@ result = rlm.completion(
 
 Depth>1 recursive subcalls are supported. The REPL provides two LM call functions:
 
-- **`llm_query(prompt)`** — Always makes a plain, single LM completion. Fast and lightweight. Use for simple extraction, summarization, or Q&A.
-- **`rlm_query(prompt)`** — Spawns a child RLM with its own REPL and iterative reasoning. Use for subtasks that need multi-step thinking or code execution. Falls back to `llm_query` when `depth >= max_depth`.
+- **`llm_query(prompt)`** — Always makes a plain, single LM completion. Fast and lightweight. Use for simple extraction, summarization, or Q&A when the prompt already fits the target model's context window.
+- **`rlm_query(prompt)`** — Spawns a child RLM with its own REPL and iterative reasoning. Use for subtasks that need multi-step thinking or code execution, and where recursive subcalls are available it can also offload a large subtask into a child RLM. Falls back to `llm_query` when `depth >= max_depth`.
 
 Both have batched variants (`llm_query_batched`, `rlm_query_batched`) for processing multiple prompts concurrently.
 
@@ -187,6 +187,7 @@ RLM raises explicit exceptions when limits are exceeded:
 - `TimeoutExceededError`
 - `TokenLimitExceededError`
 - `ErrorThresholdExceededError`
+- `ContextWindowExceededError`
 - `CancellationError` (on `KeyboardInterrupt`)
 
 All exceptions are importable from the top-level package (`from rlm import TimeoutExceededError, ...`).

--- a/rlm/__init__.py
+++ b/rlm/__init__.py
@@ -2,6 +2,7 @@ from rlm.core.rlm import RLM
 from rlm.utils.exceptions import (
     BudgetExceededError,
     CancellationError,
+    ContextWindowExceededError,
     ErrorThresholdExceededError,
     TimeoutExceededError,
     TokenLimitExceededError,
@@ -14,4 +15,5 @@ __all__ = [
     "TokenLimitExceededError",
     "ErrorThresholdExceededError",
     "CancellationError",
+    "ContextWindowExceededError",
 ]

--- a/rlm/clients/anthropic.py
+++ b/rlm/clients/anthropic.py
@@ -37,6 +37,7 @@ class AnthropicClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for Anthropic client.")
+        self.validate_prompt_context_window(prompt, model)
 
         kwargs = {"model": model, "max_tokens": self.max_tokens, "messages": messages}
         if system:
@@ -54,6 +55,7 @@ class AnthropicClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for Anthropic client.")
+        self.validate_prompt_context_window(prompt, model)
 
         kwargs = {"model": model, "max_tokens": self.max_tokens, "messages": messages}
         if system:

--- a/rlm/clients/azure_openai.py
+++ b/rlm/clients/azure_openai.py
@@ -82,6 +82,7 @@ class AzureOpenAIClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for Azure OpenAI client.")
+        self.validate_prompt_context_window(prompt, model)
 
         response = self.client.chat.completions.create(
             model=model,
@@ -103,6 +104,7 @@ class AzureOpenAIClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for Azure OpenAI client.")
+        self.validate_prompt_context_window(prompt, model)
 
         response = await self.async_client.chat.completions.create(
             model=model,

--- a/rlm/clients/base_lm.py
+++ b/rlm/clients/base_lm.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from rlm.core.types import ModelUsageSummary, UsageSummary
+from rlm.utils.token_utils import validate_prompt_fits_context_window
 
 # Default timeout for LM API calls (in seconds)
 DEFAULT_TIMEOUT: float = 300.0
@@ -18,12 +19,18 @@ class BaseLM(ABC):
         self.timeout = timeout
         self.kwargs = kwargs
 
+    def validate_prompt_context_window(
+        self, prompt: str | list[dict[str, Any]], model_name: str
+    ) -> None:
+        """Fail fast when a prompt is too large for the target model."""
+        validate_prompt_fits_context_window(prompt, model_name)
+
     @abstractmethod
-    def completion(self, prompt: str | dict[str, Any]) -> str:
+    def completion(self, prompt: str | list[dict[str, Any]]) -> str:
         raise NotImplementedError
 
     @abstractmethod
-    async def acompletion(self, prompt: str | dict[str, Any]) -> str:
+    async def acompletion(self, prompt: str | list[dict[str, Any]]) -> str:
         raise NotImplementedError
 
     @abstractmethod

--- a/rlm/clients/gemini.py
+++ b/rlm/clients/gemini.py
@@ -57,6 +57,7 @@ class GeminiClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for Gemini client.")
+        self.validate_prompt_context_window(prompt, model)
 
         config = None
         if system_instruction:
@@ -79,6 +80,7 @@ class GeminiClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for Gemini client.")
+        self.validate_prompt_context_window(prompt, model)
 
         config = None
         if system_instruction:

--- a/rlm/clients/openai.py
+++ b/rlm/clients/openai.py
@@ -77,6 +77,7 @@ class OpenAIClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for OpenAI client.")
+        self.validate_prompt_context_window(prompt, model)
 
         extra_body = {}
         if self.client.base_url == DEFAULT_PRIME_INTELLECT_BASE_URL:
@@ -101,6 +102,7 @@ class OpenAIClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for OpenAI client.")
+        self.validate_prompt_context_window(prompt, model)
 
         extra_body = {}
         if self.client.base_url == DEFAULT_PRIME_INTELLECT_BASE_URL:

--- a/rlm/clients/portkey.py
+++ b/rlm/clients/portkey.py
@@ -42,6 +42,7 @@ class PortkeyClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for Portkey client.")
+        self.validate_prompt_context_window(prompt, model)
 
         response = self.client.chat.completions.create(
             model=model,
@@ -50,7 +51,9 @@ class PortkeyClient(BaseLM):
         self._track_cost(response, model)
         return response.choices[0].message.content
 
-    async def acompletion(self, prompt: str | dict[str, Any], model: str | None = None) -> str:
+    async def acompletion(
+        self, prompt: str | list[dict[str, Any]], model: str | None = None
+    ) -> str:
         if isinstance(prompt, str):
             messages = [{"role": "user", "content": prompt}]
         elif isinstance(prompt, list) and all(isinstance(item, dict) for item in prompt):
@@ -61,6 +64,7 @@ class PortkeyClient(BaseLM):
         model = model or self.model_name
         if not model:
             raise ValueError("Model name is required for Portkey client.")
+        self.validate_prompt_context_window(prompt, model)
 
         response = await self.async_client.chat.completions.create(model=model, messages=messages)
         self._track_cost(response, model)

--- a/rlm/utils/exceptions.py
+++ b/rlm/utils/exceptions.py
@@ -65,6 +65,35 @@ class ErrorThresholdExceededError(Exception):
         )
 
 
+class ContextWindowExceededError(Exception):
+    """Raised when a prompt is estimated to exceed a model's context window."""
+
+    def __init__(
+        self,
+        model_name: str,
+        estimated_input_tokens: int,
+        context_limit: int,
+        prompt_kind: str,
+        estimation_method: str,
+        message: str | None = None,
+    ):
+        self.model_name = model_name
+        self.estimated_input_tokens = estimated_input_tokens
+        self.context_limit = context_limit
+        self.prompt_kind = prompt_kind
+        self.estimation_method = estimation_method
+        super().__init__(
+            message
+            or (
+                f"Context window exceeded for model '{model_name}': estimated "
+                f"{estimated_input_tokens:,} input tokens for {prompt_kind} prompt exceeds "
+                f"{context_limit:,}-token limit ({estimation_method}). Reduce, chunk, or "
+                "summarize the prompt first, or use rlm_query(...) where recursive subcalls "
+                "are supported."
+            )
+        )
+
+
 class CancellationError(Exception):
     """Raised when the RLM execution is cancelled by the user."""
 

--- a/rlm/utils/prompts.py
+++ b/rlm/utils/prompts.py
@@ -9,17 +9,17 @@ RLM_SYSTEM_PROMPT = textwrap.dedent(
 
 The REPL environment is initialized with:
 1. A `context` variable that contains extremely important information about your query. You should check the content of the `context` variable to understand what you are working with. Make sure you look through it sufficiently as you answer your query.
-2. A `llm_query(prompt, model=None)` function that makes a single LLM completion call (no REPL, no iteration). Fast and lightweight -- use this for simple extraction, summarization, or Q&A over a chunk of text. The sub-LLM can handle around 500K chars.
+2. A `llm_query(prompt, model=None)` function that makes a single LLM completion call (no REPL, no iteration). Fast and lightweight -- use this for simple extraction, summarization, or Q&A when the prompt you send already fits the target model's context window.
 3. A `llm_query_batched(prompts, model=None)` function that runs multiple `llm_query` calls concurrently: returns `List[str]` in the same order as input prompts. Much faster than sequential `llm_query` calls for independent queries.
-4. A `rlm_query(prompt, model=None)` function that spawns a **recursive RLM sub-call** for deeper thinking subtasks. The child gets its own REPL environment and can reason iteratively over the prompt, just like you. Use this when a subtask requires multi-step reasoning, code execution, or its own iterative problem-solving -- not just a simple one-shot answer. Falls back to `llm_query` if recursion is not available.
+4. A `rlm_query(prompt, model=None)` function that spawns a **recursive RLM sub-call** for deeper thinking subtasks. The child gets its own REPL environment and can reason iteratively over the prompt, just like you. Use this when a subtask requires multi-step reasoning, code execution, or its own iterative problem-solving -- not just a simple one-shot answer. It can also help offload a large subtask into a child RLM when recursive subcalls are available. Falls back to `llm_query` if recursion is not available.
 5. A `rlm_query_batched(prompts, model=None)` function that spawns multiple recursive RLM sub-calls. Each prompt gets its own child RLM. Falls back to `llm_query_batched` if recursion is not available.
 6. A `SHOW_VARS()` function that returns all variables you have created in the REPL. Use this to check what variables exist before using FINAL_VAR.
 7. The ability to use `print()` statements to view the output of your REPL code and continue your reasoning.
 {custom_tools_section}
 
 **When to use `llm_query` vs `rlm_query`:**
-- Use `llm_query` for simple, one-shot tasks: extracting info from a chunk, summarizing text, answering a factual question, classifying content. These are fast single LLM calls.
-- Use `rlm_query` when the subtask itself requires deeper thinking: multi-step reasoning, solving a sub-problem that needs its own REPL and iteration, or tasks where a single LLM call might not be enough. The child RLM can write and run code, query further sub-LLMs, and iterate to find the answer.
+- Use `llm_query` for simple, one-shot tasks: extracting info from a chunk, summarizing text, answering a factual question, classifying content. These are fast single LLM calls, but the prompt still needs to fit the target model's context window. If it does not fit, split or summarize first.
+- Use `rlm_query` when the subtask itself requires deeper thinking: multi-step reasoning, solving a sub-problem that needs its own REPL and iteration, or tasks where a single LM call might not be enough. Where recursive subcalls are available, it can also offload a large subtask into a child RLM that receives that subtask as its own context.
 
 **Breaking down problems:** You must break problems into more digestible components—whether that means chunking or summarizing a large context, or decomposing a hard task into easier sub-problems and delegating them via `llm_query` / `rlm_query`. Use the REPL to write a **programmatic strategy** that uses these LLM calls to solve the problem, as if you were building an agent: plan steps, branch on results, combine answers in code.
 
@@ -37,7 +37,7 @@ final_answer = llm_query(f"An electron entered a B field and underwent helical m
 You will only be able to see truncated outputs from the REPL environment, so you should use the query LLM function on variables you want to analyze. You will find this function especially useful when you have to analyze the semantics of the context. Use these variables as buffers to build up your final answer.
 Make sure to explicitly look through the entire context in REPL before answering your query. Break the context and the problem into digestible pieces: e.g. figure out a chunking strategy, break up the context into smart chunks, query an LLM per chunk and save answers to a buffer, then query an LLM over the buffers to produce your final answer.
 
-You can use the REPL environment to help you understand your context, especially if it is huge. Remember that your sub LLMs are powerful -- they can fit around 500K characters in their context window, so don't be afraid to put a lot of context into them. For example, a viable strategy is to feed 10 documents per sub-LLM query. Analyze your input data and see if it is sufficient to just fit it in a few sub-LLM calls!
+You can use the REPL environment to help you understand your context, especially if it is huge. Remember that your sub-LLM calls are still bounded by the target model's context window, so do not assume a very large payload will fit in one call. Measure chunk sizes and split or summarize when needed. For example, a viable strategy may be to feed several documents per sub-LLM query only after checking that the combined chunk fits.
 
 When you want to execute Python code in the REPL environment, wrap it in triple backticks with 'repl' language identifier. For example, say we want our recursive model to search for the magic number in the context (assuming the context is a string), and the context is very long, so we want to chunk it:
 ```repl

--- a/rlm/utils/token_utils.py
+++ b/rlm/utils/token_utils.py
@@ -7,6 +7,8 @@ with ~4 characters per token.
 
 from typing import Any
 
+from rlm.utils.exceptions import ContextWindowExceededError
+
 # Default context limit when model is unknown (tokens)
 DEFAULT_CONTEXT_LIMIT = 128_000
 
@@ -122,6 +124,59 @@ def _count_tokens_tiktoken(messages: list[dict[str, Any]], model_name: str) -> i
     return total
 
 
+def _count_text_tokens_tiktoken(text: str, model_name: str) -> int | None:
+    """Count text tokens with tiktoken if available. Returns None on failure."""
+    try:
+        import tiktoken
+    except ImportError:
+        return None
+    try:
+        enc = tiktoken.encoding_for_model(model_name)
+    except Exception:
+        try:
+            enc = tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            return None
+    return len(enc.encode(text))
+
+
+def _estimate_text_tokens_with_method(text: str, model_name: str) -> tuple[int, str]:
+    """Estimate token count for raw text and report the estimation method used."""
+    if model_name and model_name != "unknown":
+        n = _count_text_tokens_tiktoken(text, model_name)
+        if n is not None:
+            return n, "tiktoken estimate"
+    return (
+        (len(text) + CHARS_PER_TOKEN_ESTIMATE - 1) // CHARS_PER_TOKEN_ESTIMATE,
+        f"character estimate ({CHARS_PER_TOKEN_ESTIMATE} chars/token)",
+    )
+
+
+def _estimate_message_tokens_with_method(
+    messages: list[dict[str, Any]], model_name: str
+) -> tuple[int, str]:
+    """Estimate token count for a chat-style message list."""
+    if not messages:
+        return 0, "empty prompt"
+    if model_name and model_name != "unknown":
+        n = _count_tokens_tiktoken(messages, model_name)
+        if n is not None:
+            return n, "tiktoken estimate"
+    total_chars = 0
+    for m in messages:
+        raw = m.get("content", "") or ""
+        total_chars += len(raw) if isinstance(raw, str) else len(str(raw))
+    return (
+        (total_chars + CHARS_PER_TOKEN_ESTIMATE - 1) // CHARS_PER_TOKEN_ESTIMATE,
+        f"character estimate ({CHARS_PER_TOKEN_ESTIMATE} chars/token)",
+    )
+
+
+def estimate_text_tokens(text: str, model_name: str) -> int:
+    """Estimate token count for raw text."""
+    return _estimate_text_tokens_with_method(text, model_name)[0]
+
+
 def count_tokens(messages: list[dict[str, Any]], model_name: str) -> int:
     """
     Count tokens in a list of message dicts (role, content).
@@ -129,15 +184,42 @@ def count_tokens(messages: list[dict[str, Any]], model_name: str) -> int:
     Uses tiktoken for OpenAI-style models when the package is available;
     otherwise estimates with character length / CHARS_PER_TOKEN_ESTIMATE.
     """
-    if not messages:
-        return 0
-    if model_name and model_name != "unknown":
-        n = _count_tokens_tiktoken(messages, model_name)
-        if n is not None:
-            return n
-    # Fallback: count chars (stringify in case content is not str, e.g. list)
-    total_chars = 0
-    for m in messages:
-        raw = m.get("content", "") or ""
-        total_chars += len(raw) if isinstance(raw, str) else len(str(raw))
-    return (total_chars + CHARS_PER_TOKEN_ESTIMATE - 1) // CHARS_PER_TOKEN_ESTIMATE
+    return _estimate_message_tokens_with_method(messages, model_name)[0]
+
+
+def count_prompt_tokens(prompt: str | list[dict[str, Any]], model_name: str) -> int:
+    """Estimate token count for a plain prompt string or a chat message list."""
+    return _count_prompt_tokens_with_method(prompt, model_name)[0]
+
+
+def validate_prompt_fits_context_window(
+    prompt: str | list[dict[str, Any]], model_name: str
+) -> None:
+    """Raise ContextWindowExceededError when a prompt is too large for the model."""
+    estimated_tokens, estimation_method, prompt_kind = _count_prompt_tokens_with_method(
+        prompt, model_name
+    )
+    context_limit = get_context_limit(model_name)
+    if estimated_tokens > context_limit:
+        raise ContextWindowExceededError(
+            model_name=model_name,
+            estimated_input_tokens=estimated_tokens,
+            context_limit=context_limit,
+            prompt_kind=prompt_kind,
+            estimation_method=estimation_method,
+        )
+
+
+def _count_prompt_tokens_with_method(
+    prompt: str | list[dict[str, Any]], model_name: str
+) -> tuple[int, str, str]:
+    """Estimate prompt tokens and return (count, method, prompt_kind)."""
+    if isinstance(prompt, str):
+        count, method = _estimate_message_tokens_with_method(
+            [{"role": "user", "content": prompt}], model_name
+        )
+        return count, method, "string"
+    if isinstance(prompt, list) and all(isinstance(item, dict) for item in prompt):
+        count, method = _estimate_message_tokens_with_method(prompt, model_name)
+        return count, method, "message-list"
+    raise ValueError(f"Invalid prompt type: {type(prompt)}")

--- a/tests/clients/test_context_window.py
+++ b/tests/clients/test_context_window.py
@@ -1,0 +1,162 @@
+"""Tests for client-side prompt-size validation."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rlm.clients.anthropic import AnthropicClient
+from rlm.clients.azure_openai import AzureOpenAIClient
+from rlm.clients.gemini import GeminiClient
+from rlm.clients.openai import OpenAIClient
+from rlm.clients.portkey import PortkeyClient
+from rlm.utils.exceptions import ContextWindowExceededError
+
+
+def _context_window_error() -> ContextWindowExceededError:
+    return ContextWindowExceededError(
+        model_name="gpt-4",
+        estimated_input_tokens=9_000,
+        context_limit=8_192,
+        prompt_kind="string",
+        estimation_method="character estimate (4 chars/token)",
+    )
+
+
+def test_openai_client_validates_before_sync_sdk_call():
+    """OpenAI client should fail before hitting the sync SDK call."""
+    mock_client = MagicMock()
+
+    with patch("rlm.clients.openai.openai.OpenAI", return_value=mock_client):
+        with patch("rlm.clients.openai.openai.AsyncOpenAI"):
+            client = OpenAIClient(api_key="test-key", model_name="gpt-4")
+
+    with patch.object(
+        OpenAIClient, "validate_prompt_context_window", side_effect=_context_window_error()
+    ) as mock_validate:
+        with pytest.raises(ContextWindowExceededError):
+            client.completion("too big")
+
+    mock_validate.assert_called_once_with("too big", "gpt-4")
+    mock_client.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_openai_client_validates_before_async_sdk_call():
+    """OpenAI async client should fail before hitting the async SDK call."""
+    mock_async_client = MagicMock()
+    mock_async_client.chat.completions.create = AsyncMock()
+
+    with patch("rlm.clients.openai.openai.OpenAI"):
+        with patch("rlm.clients.openai.openai.AsyncOpenAI", return_value=mock_async_client):
+            client = OpenAIClient(api_key="test-key", model_name="gpt-4")
+
+    with patch.object(
+        OpenAIClient, "validate_prompt_context_window", side_effect=_context_window_error()
+    ) as mock_validate:
+        with pytest.raises(ContextWindowExceededError):
+            await client.acompletion("too big")
+
+    mock_validate.assert_called_once_with("too big", "gpt-4")
+    mock_async_client.chat.completions.create.assert_not_awaited()
+
+
+def test_openai_client_sync_sdk_call_still_runs_for_small_prompt():
+    """Small prompts should still reach the provider SDK."""
+    mock_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+        usage=SimpleNamespace(
+            prompt_tokens=3,
+            completion_tokens=2,
+            total_tokens=5,
+            cost=None,
+            model_extra=None,
+        ),
+    )
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_response
+
+    with patch("rlm.clients.openai.openai.OpenAI", return_value=mock_client):
+        with patch("rlm.clients.openai.openai.AsyncOpenAI"):
+            client = OpenAIClient(api_key="test-key", model_name="gpt-4")
+
+    assert client.completion("small prompt") == "ok"
+    mock_client.chat.completions.create.assert_called_once()
+
+
+def test_anthropic_client_validates_before_sdk_call():
+    """Anthropic client should fail before hitting the provider SDK."""
+    mock_client = MagicMock()
+
+    with patch("rlm.clients.anthropic.anthropic.Anthropic", return_value=mock_client):
+        with patch("rlm.clients.anthropic.anthropic.AsyncAnthropic"):
+            client = AnthropicClient(api_key="test-key", model_name="gpt-4")
+
+    with patch.object(
+        AnthropicClient, "validate_prompt_context_window", side_effect=_context_window_error()
+    ) as mock_validate:
+        with pytest.raises(ContextWindowExceededError):
+            client.completion("too big")
+
+    mock_validate.assert_called_once_with("too big", "gpt-4")
+    mock_client.messages.create.assert_not_called()
+
+
+def test_gemini_client_validates_before_sdk_call():
+    """Gemini client should fail before hitting the provider SDK."""
+    mock_client = MagicMock()
+
+    with patch("rlm.clients.gemini.genai.Client", return_value=mock_client):
+        client = GeminiClient(api_key="test-key", model_name="gpt-4")
+
+    with patch.object(
+        GeminiClient, "validate_prompt_context_window", side_effect=_context_window_error()
+    ) as mock_validate:
+        with pytest.raises(ContextWindowExceededError):
+            client.completion("too big")
+
+    mock_validate.assert_called_once_with("too big", "gpt-4")
+    mock_client.models.generate_content.assert_not_called()
+
+
+def test_azure_openai_client_validates_before_sdk_call():
+    """Azure OpenAI client should fail before hitting the provider SDK."""
+    mock_client = MagicMock()
+
+    with patch("rlm.clients.azure_openai.openai.AzureOpenAI", return_value=mock_client):
+        with patch("rlm.clients.azure_openai.openai.AsyncAzureOpenAI"):
+            client = AzureOpenAIClient(
+                api_key="test-key",
+                model_name="gpt-4",
+                azure_endpoint="https://test.openai.azure.com",
+            )
+
+    with patch.object(
+        AzureOpenAIClient,
+        "validate_prompt_context_window",
+        side_effect=_context_window_error(),
+    ) as mock_validate:
+        with pytest.raises(ContextWindowExceededError):
+            client.completion("too big")
+
+    mock_validate.assert_called_once_with("too big", "gpt-4")
+    mock_client.chat.completions.create.assert_not_called()
+
+
+def test_portkey_client_validates_before_sdk_call():
+    """Portkey client should fail before hitting the provider SDK."""
+    mock_client = MagicMock()
+
+    with patch("rlm.clients.portkey.Portkey", return_value=mock_client):
+        with patch("rlm.clients.portkey.AsyncPortkey"):
+            client = PortkeyClient(api_key="test-key", model_name="gpt-4")
+
+    with patch.object(
+        PortkeyClient, "validate_prompt_context_window", side_effect=_context_window_error()
+    ) as mock_validate:
+        with pytest.raises(ContextWindowExceededError):
+            client.completion("too big")
+
+    mock_validate.assert_called_once_with("too big", "gpt-4")
+    mock_client.chat.completions.create.assert_not_called()

--- a/tests/mock_lm.py
+++ b/tests/mock_lm.py
@@ -20,7 +20,7 @@ class MockLM(BaseLM):
         self,
         model_name: str = "mock-model",
         responses: list[str] | None = None,
-        response_fn: Callable[[str | dict[str, Any]], str] | None = None,
+        response_fn: Callable[[str | list[dict[str, Any]]], str] | None = None,
         **kwargs: Any,
     ):
         super().__init__(model_name=model_name, **kwargs)
@@ -28,7 +28,7 @@ class MockLM(BaseLM):
         self._response_fn = response_fn
         self._call_count = 0
 
-    def completion(self, prompt: str | dict[str, Any]) -> str:
+    def completion(self, prompt: str | list[dict[str, Any]]) -> str:
         self._call_count += 1
         if self._responses is not None:
             if not self._responses:
@@ -39,7 +39,7 @@ class MockLM(BaseLM):
         prompt_str = prompt if isinstance(prompt, str) else str(prompt)[:80]
         return f"Mock response to: {prompt_str}"
 
-    async def acompletion(self, prompt: str | dict[str, Any]) -> str:
+    async def acompletion(self, prompt: str | list[dict[str, Any]]) -> str:
         return self.completion(prompt)
 
     def get_usage_summary(self) -> UsageSummary:

--- a/tests/test_lm_handler.py
+++ b/tests/test_lm_handler.py
@@ -2,6 +2,7 @@
 
 from rlm.core.comms_utils import LMRequest, send_lm_request, send_lm_request_batched
 from rlm.core.lm_handler import LMHandler
+from rlm.utils.exceptions import ContextWindowExceededError
 from tests.mock_lm import MockLM
 
 
@@ -43,3 +44,46 @@ def test_lm_handler_batched_many_prompts_semaphore_cap():
     for i, resp in enumerate(result):
         assert resp.success, (i, resp.error)
         assert resp.chat_completion.response == f"resp-{i}"
+
+
+def test_lm_handler_single_request_propagates_context_window_error():
+    """Client preflight errors should be returned as handler error responses."""
+
+    def raise_context_window_error(_prompt):
+        raise ContextWindowExceededError(
+            model_name="gpt-4",
+            estimated_input_tokens=9_000,
+            context_limit=8_192,
+            prompt_kind="string",
+            estimation_method="character estimate (4 chars/token)",
+        )
+
+    mock = MockLM(model_name="gpt-4", response_fn=raise_context_window_error)
+    with LMHandler(client=mock) as handler:
+        response = send_lm_request(handler.address, LMRequest(prompt="too big"))
+
+    assert not response.success
+    assert response.error is not None
+    assert "Context window exceeded" in response.error
+
+
+def test_lm_handler_batched_request_propagates_context_window_error():
+    """Batched handler failures should fan out as one error response per prompt."""
+
+    def raise_context_window_error(_prompt):
+        raise ContextWindowExceededError(
+            model_name="gpt-4",
+            estimated_input_tokens=9_000,
+            context_limit=8_192,
+            prompt_kind="string",
+            estimation_method="character estimate (4 chars/token)",
+        )
+
+    mock = MockLM(model_name="gpt-4", response_fn=raise_context_window_error)
+    with LMHandler(client=mock) as handler:
+        responses = send_lm_request_batched(handler.address, ["a", "b", "c"])
+
+    assert len(responses) == 3
+    assert all(not response.success for response in responses)
+    assert all(response.error is not None for response in responses)
+    assert all("Context window exceeded" in response.error for response in responses)

--- a/tests/test_rlm_query.py
+++ b/tests/test_rlm_query.py
@@ -4,8 +4,11 @@ import threading
 import time
 from unittest.mock import MagicMock
 
+from rlm.core.lm_handler import LMHandler
 from rlm.core.types import RLMChatCompletion, UsageSummary
 from rlm.environments.local_repl import LocalREPL
+from rlm.utils.exceptions import ContextWindowExceededError
+from tests.mock_lm import MockLM
 
 
 def _make_completion(response: str) -> RLMChatCompletion:
@@ -71,6 +74,24 @@ class TestRlmQueryWithoutSubcallFn:
         repl.execute_code("response = rlm_query('test')")
         assert "Error" in repl.locals["response"]
         repl.cleanup()
+
+    def test_rlm_query_fallback_surfaces_context_window_error(self):
+        """Leaf fallback should surface context-window failures from plain LM calls."""
+
+        def raise_context_window_error(_prompt):
+            raise ContextWindowExceededError(
+                model_name="gpt-4",
+                estimated_input_tokens=9_000,
+                context_limit=8_192,
+                prompt_kind="string",
+                estimation_method="character estimate (4 chars/token)",
+            )
+
+        mock = MockLM(model_name="gpt-4", response_fn=raise_context_window_error)
+        with LMHandler(client=mock) as handler:
+            with LocalREPL(lm_handler_address=handler.address) as repl:
+                repl.execute_code("response = rlm_query('too big')")
+                assert "Context window exceeded" in repl.locals["response"]
 
 
 class TestRlmQueryBatchedWithSubcallFn:

--- a/tests/test_subcall.py
+++ b/tests/test_subcall.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, patch
 import rlm.core.rlm as rlm_module
 from rlm import RLM
 from rlm.core.types import ModelUsageSummary, UsageSummary
+from rlm.utils.exceptions import ContextWindowExceededError
 
 
 def create_mock_lm(responses: list[str], model_name: str = "mock-model") -> Mock:
@@ -247,6 +248,35 @@ class TestSubcallErrorsPropagation:
                 parent._subcall("test prompt")
 
             assert captured_child_params.get("max_errors") is None
+
+            parent.close()
+
+
+class TestSubcallLeafFallbackErrors:
+    """Tests for plain LM fallback behavior at max depth."""
+
+    def test_max_depth_plain_lm_error_is_returned_in_completion(self):
+        """Context-window failures in the leaf LM call should be surfaced cleanly."""
+        with patch.object(rlm_module, "get_client") as mock_get_client:
+            mock_lm = create_mock_lm([])
+            mock_lm.completion.side_effect = ContextWindowExceededError(
+                model_name="gpt-4",
+                estimated_input_tokens=9_000,
+                context_limit=8_192,
+                prompt_kind="string",
+                estimation_method="character estimate (4 chars/token)",
+            )
+            mock_get_client.return_value = mock_lm
+
+            parent = RLM(
+                backend="openai",
+                backend_kwargs={"model_name": "parent-model"},
+                max_depth=1,
+            )
+
+            result = parent._subcall("too big")
+
+            assert "Context window exceeded" in result.response
 
             parent.close()
 

--- a/tests/test_token_utils.py
+++ b/tests/test_token_utils.py
@@ -1,0 +1,59 @@
+"""Tests for token estimation and context-window validation helpers."""
+
+import pytest
+
+from rlm.utils.exceptions import ContextWindowExceededError
+from rlm.utils.token_utils import (
+    CHARS_PER_TOKEN_ESTIMATE,
+    DEFAULT_CONTEXT_LIMIT,
+    count_prompt_tokens,
+    count_tokens,
+    estimate_text_tokens,
+    get_context_limit,
+    validate_prompt_fits_context_window,
+)
+
+
+def test_get_context_limit_uses_longest_matching_key():
+    """Model aliases should resolve to the most specific configured limit."""
+    assert get_context_limit("@openai/gpt-4o-mini") == 128_000
+
+
+def test_get_context_limit_falls_back_for_unknown_models():
+    """Unknown models should use the conservative default context limit."""
+    assert get_context_limit("my-custom-model") == DEFAULT_CONTEXT_LIMIT
+
+
+def test_estimate_text_tokens_uses_character_fallback_for_unknown_models():
+    """Unknown models should use the character-based estimator."""
+    text = "x" * (CHARS_PER_TOKEN_ESTIMATE * 10 + 1)
+    assert estimate_text_tokens(text, "unknown") == 11
+
+
+def test_count_prompt_tokens_accepts_message_lists():
+    """Message-list prompts should be counted with the shared message estimator."""
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Summarize this."},
+    ]
+    assert count_prompt_tokens(messages, "unknown") == count_tokens(messages, "unknown")
+
+
+def test_validate_prompt_fits_context_window_allows_small_prompt():
+    """Validation should pass silently when prompt fits the selected model."""
+    validate_prompt_fits_context_window("short prompt", "gpt-4")
+
+
+def test_validate_prompt_fits_context_window_raises_with_metadata():
+    """Validation should raise a descriptive error for oversized prompts."""
+    prompt = "x" * (CHARS_PER_TOKEN_ESTIMATE * 9_000)
+
+    with pytest.raises(ContextWindowExceededError) as exc_info:
+        validate_prompt_fits_context_window(prompt, "gpt-4")
+
+    error = exc_info.value
+    assert error.model_name == "gpt-4"
+    assert error.context_limit == 8_192
+    assert error.estimated_input_tokens > error.context_limit
+    assert error.prompt_kind == "string"
+    assert "Context window exceeded" in str(error)


### PR DESCRIPTION
## Summary

This PR adds a fail-fast context-window guard for plain LM calls and clarifies when models should use `llm_query(...)` versus `rlm_query(...)`.

Closes #42.

## Problem

Issue #42 reports context-window failures when large prompts are sent through sub-calls. After reviewing the code path, the main practical gap was not child `RLM` prompt inheritance, but plain `llm_query(...)` and leaf LM calls: they could send oversized prompts directly to provider SDKs with no preflight validation, which led to provider-specific failures and inconsistent error messages.

## What Changed

- Added `ContextWindowExceededError` for oversized prompt validation failures.
- Added shared prompt-fit utilities in `rlm.utils.token_utils`:
  - `estimate_text_tokens(...)`
  - `count_prompt_tokens(...)`
  - `validate_prompt_fits_context_window(...)`
- Enforced prompt-size validation before provider SDK calls in all built-in LM clients:
  - OpenAI
  - Anthropic
  - Gemini
  - Azure OpenAI
  - Portkey
- Reused the existing `LMHandler` and REPL error propagation path so validation errors surface cleanly inside `llm_query(...)` / `rlm_query(...)` fallback behavior.
- Re-exported `ContextWindowExceededError` from the top-level `rlm` package.
- Updated system prompt and docs to clarify:
  - `llm_query(...)` is for prompts that already fit the target model's context window.
  - `rlm_query(...)` is the deeper/offloaded path where recursive subcalls are available.

## Design Notes

- This keeps the fix intentionally narrow and low-complexity.
- There is no auto-chunking, auto-routing, or fallback summarization in this PR.
- Existing batch semantics are preserved.
- The validation is shared and provider-agnostic, while still using the repo's existing model limit table and token estimation helpers.

## Tests

Added and updated tests for:

- token estimation and validation helpers
- client-side preflight validation before SDK calls
- `LMHandler` propagation of context-window failures
- `LocalREPL` / `rlm_query(...)` fallback error surfacing
- max-depth plain LM fallback behavior in `_subcall`

## Verification

```bash
UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q
```

Result:

- `292 passed, 7 skipped`
