### PR TITLE
Add Python >= 3.11 requirement note to Quick Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ This repository provides an extensible inference engine for using RLMs around st
 > This repository contains inference code for RLMs with support for various sandbox environments. Open-source contributions are welcome. This repository is maintained by the authors of the paper from the MIT OASYS lab.
 
 ## Quick Setup
+> [!NOTE]
+> `rlms` requires **Python 3.11 or later**.
+
 You can try out RLMs quickly by installing from PyPi:
 ```bash
 pip install rlms


### PR DESCRIPTION
Fixes #113.

On Python 3.10, running  silently installs a broken v0.0.1a1 stub (which has no Python version constraint) instead of the real v0.1.0 release (which requires Python >= 3.11). Users get a silent broken install with no indication anything went wrong.

This PR adds a prominent note above the Quick Setup section stating the Python 3.11+ requirement. Ideally the old stub would also be yanked from PyPI.