### PR TITLE
New dict-based Final Answer format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ Environments must provide these globals to executed code:
 - `llm_query_batched(prompts, model=None)`: Batched plain LM completions
 - `rlm_query(prompt, model=None)`: Recursive child RLM call (own REPL + iteration). Falls back to `llm_query` at max depth.
 - `rlm_query_batched(prompts, model=None)`: Batched recursive child RLM calls
-- `FINAL_VAR(variable_name)`: For returning final answers
+- `answer`: A dict (`{"content": "", "ready": False}`); the model sets `answer["content"]` and `answer["ready"] = True` to return a final answer. The env surfaces the content on `REPLResult.final_answer` once `ready` flips truthy.
 - `SHOW_VARS()`: For listing available variables
 
 ### Example Structure
@@ -208,7 +208,7 @@ class MyEnvironment(NonIsolatedEnv):
 - Environment works with basic RLM completion calls
 - `cleanup()` properly releases all resources
 - Sub-LM calls work via `llm_query()` and `rlm_query()`
-- Reserved names (`llm_query`, `rlm_query`, `context`, `history`, `FINAL_VAR`, `SHOW_VARS`) are restored after each execution
+- Reserved names (`llm_query`, `rlm_query`, `context`, `history`, `answer`, `SHOW_VARS`) are restored after each execution
 
 ## Architecture: Environment ↔ LM Handler Communication
 

--- a/docs/api/rlm.md
+++ b/docs/api/rlm.md
@@ -255,12 +255,15 @@ Override the default RLM system prompt. The default prompt instructs the LM on:
 - How to use the `context` variable
 - How to call `llm_query()` / `llm_query_batched()` for plain LM calls
 - How to call `rlm_query()` / `rlm_query_batched()` for recursive sub-calls
-- How to signal completion with `FINAL()` or `FINAL_VAR()`
+- How to signal completion by setting `answer["content"]` and `answer["ready"] = True`
 
 ```python
 custom_prompt = """You are a data analysis expert.
 Use the REPL to analyze the context variable.
-When done, output FINAL(your answer)."""
+When done, run a ```repl``` block that does:
+    answer["content"] = "your final answer here"
+    answer["ready"] = True
+"""
 
 rlm = RLM(..., custom_system_prompt=custom_prompt)
 ```
@@ -372,7 +375,7 @@ custom_tools = {
 }
 ```
 
-Reserved names (`llm_query`, `rlm_query`, `context`, `history`, `FINAL_VAR`, `SHOW_VARS`, and their batched variants) cannot be used as tool names.
+Reserved names (`llm_query`, `rlm_query`, `context`, `history`, `answer`, `SHOW_VARS`, and their batched variants) cannot be used as tool names.
 
 ---
 
@@ -550,7 +553,7 @@ The following functions are available to model-generated code inside the REPL:
 | `llm_query_batched(prompts, model=None)` | Multiple plain LM completions concurrently. |
 | `rlm_query(prompt, model=None)` | Spawn a child RLM with its own REPL for deeper thinking. Falls back to `llm_query` at max depth. |
 | `rlm_query_batched(prompts, model=None)` | Spawn multiple child RLMs. Falls back to `llm_query_batched` at max depth. |
-| `FINAL_VAR(variable_name)` | Return a REPL variable as the final answer. |
+| `answer` | A dict (`{"content": "", "ready": False}`). Set `answer["content"]` to your final answer and `answer["ready"] = True` to terminate the run. |
 | `SHOW_VARS()` | List all user-created variables in the REPL. |
 | `print(...)` | Print output visible to the model in the next iteration. |
 
@@ -570,7 +573,7 @@ rlm = RLM(backend="unknown")
 # Raises: ValueError: Unknown backend: unknown
 ```
 
-If the RLM exhausts `max_iterations` without finding a `FINAL()` / `FINAL_VAR()` answer, it prompts the LM one more time to provide a final answer based on the conversation history.
+If the RLM exhausts `max_iterations` without the model setting `answer["ready"] = True`, it prompts the LM one more time to provide a final answer based on the conversation history.
 
 RLM raises explicit exceptions when limits are exceeded:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ An RLM completion involves three cooperating pieces:
 │     b. Extract ```repl``` code blocks from response            │
 │     c. Execute code in LocalREPL                               │
 │     d. Append stdout/stderr to message history                 │
-│     e. Repeat until FINAL_VAR / FINAL or limits exceeded       │
+│     e. Repeat until answer["ready"] is True or limits exceeded │
 │  4. Tear down handler and environment                          │
 └────────────────────────────────────────────────────────────────┘
 ```
@@ -139,7 +139,6 @@ globals (shared across all executions):
 ├── llm_query_batched() → batched plain LM calls
 ├── rlm_query()         → recursive RLM sub-call (or fallback to llm_query)
 ├── rlm_query_batched() → batched recursive sub-calls
-├── FINAL_VAR()         → mark a variable as the final answer
 ├── SHOW_VARS()         → list user-created variables
 └── <custom_tools>      → user-provided callable tools
 
@@ -148,6 +147,7 @@ locals (accumulates user variables):
 ├── context_0           → first context payload
 ├── context_1, …        → additional contexts (persistent mode)
 ├── history             → conversation history (persistent/compaction mode)
+├── answer              → {"content": "", "ready": False}; set ready=True to finish
 └── <user variables>    → anything created by model code
 ```
 
@@ -333,13 +333,13 @@ RLM (depth=0)
  │       │           │   │
  │       │           │   └─ llm_query() → TCP to Handler #2 → LM API → response
  │       │           │
- │       │           ├─ Child iteration 2: LM calls FINAL_VAR(result)
+ │       │           ├─ Child iteration 2: LM sets answer["content"]=result, answer["ready"]=True
  │       │           │
  │       │           └─ Returns RLMChatCompletion to parent
  │       │
- │       └─ answer = child_completion.response
+ │       └─ child_response = child_completion.response
  │
- ├─ Iteration 2: LM uses answer, calls FINAL_VAR(final)
+ ├─ Iteration 2: LM uses child_response, sets answer["content"]=final, answer["ready"]=True
  │
  ├─ LMHandler #1 stops
  └─ Returns RLMChatCompletion to user

--- a/examples/compaction_example.py
+++ b/examples/compaction_example.py
@@ -56,7 +56,7 @@ prompt = (
     "Step 4: Compute and print the mean, median, min, max, and standard deviation "
     "of `data_b`. Store the mean as `mean_b`.\n\n"
     "Step 5: You previously computed `mean_a` and `mean_b`. "
-    "Compute final_answer = round(mean_a + mean_b, 2) and call FINAL_VAR(final_answer)."
+    "Compute final_value = round(mean_a + mean_b, 2), then set answer['content'] = final_value and answer['ready'] = True."
 )
 
 result = rlm.completion(prompt, root_prompt=prompt)

--- a/examples/compaction_history_retrieval_example.py
+++ b/examples/compaction_history_retrieval_example.py
@@ -52,8 +52,8 @@ prompt = (
     "Step 6: Compute the standard deviation of each group. Print all four. "
     "Store as `s1`, `s2`, `s3`, `s4`.\n\n"
     "Step 7: You previously computed four means and four standard deviations. "
-    "Compute final_answer = round((m1 + m2 + m3 + m4) / (s1 + s2 + s3 + s4), 4). "
-    "Print the full equation with values and call FINAL_VAR(final_answer)."
+    "Compute final_value = round((m1 + m2 + m3 + m4) / (s1 + s2 + s3 + s4), 4). "
+    "Print the full equation with values, then set answer['content'] = final_value and answer['ready'] = True."
 )
 
 result = rlm.completion(prompt, root_prompt=prompt)

--- a/examples/daytona_repl_example.py
+++ b/examples/daytona_repl_example.py
@@ -58,9 +58,8 @@ def main():
             print("Executed: print(x * 2)")
             print(f"Stdout: {result.stdout.strip()}")
 
-            result = repl.execute_code("answer = 42")
-            result = repl.execute_code('print(FINAL_VAR("answer"))')
-            print(f"FINAL_VAR('answer'): {result.stdout.strip()}")
+            result = repl.execute_code('answer["content"] = 42\nanswer["ready"] = True')
+            print(f"answer-dict final answer: {result.final_answer!r}")
 
         # Example 2: With LLM handler
         print("\n[2] Code execution with LLM handler")

--- a/examples/depth_metadata_example.py
+++ b/examples/depth_metadata_example.py
@@ -107,7 +107,7 @@ def main():
     prompt = (
         "Use rlm_query() to ask the sub-model: 'What are the first 5 prime numbers? "
         "Reply with just the numbers separated by commas.' "
-        "Store the response in a variable called 'primes', then return it with FINAL_VAR('primes')."
+        "Store the response in a variable called 'primes', then set answer['content'] = primes and answer['ready'] = True."
     )
 
     print("Prompt:", prompt)

--- a/examples/logger_example.py
+++ b/examples/logger_example.py
@@ -29,7 +29,7 @@ rlm = RLM(
     verbose=True,
 )
 
-prompt = "Compute the sum 1 + 2 + 3 + 4 + 5 and print the result using a REPL block, then return it with FINAL_VAR."
+prompt = "Compute the sum 1 + 2 + 3 + 4 + 5 and print the result using a REPL block, then set answer['content'] to the sum and answer['ready'] = True."
 result = rlm.completion(prompt)
 
 print("Response:", result.response)

--- a/examples/modal_repl_example.py
+++ b/examples/modal_repl_example.py
@@ -53,9 +53,8 @@ def main():
         print("Executed: print(x * 2)")
         print(f"Stdout: {result.stdout.strip()}")
 
-        result = repl.execute_code("answer = 42")
-        result = repl.execute_code('print(FINAL_VAR("answer"))')
-        print(f"FINAL_VAR('answer'): {result.stdout.strip()}")
+        result = repl.execute_code('answer["content"] = 42\nanswer["ready"] = True')
+        print(f"answer-dict final answer: {result.final_answer!r}")
 
     # Example 2: With LLM handler
     print("\n[2] Code execution with LLM handler")

--- a/examples/rlm_query_batched_example.py
+++ b/examples/rlm_query_batched_example.py
@@ -106,8 +106,8 @@ def main():
         "  1. 'What are the first 5 prime numbers? Reply with just the numbers.'\n"
         "  2. 'What are the first 5 even numbers? Reply with just the numbers.'\n"
         "  3. 'What are the first 5 square numbers? Reply with just the numbers.'\n"
-        "Store the list of responses in a variable called 'answers', "
-        "then return it with FINAL_VAR(answers)."
+        "Store the list of responses in a variable called 'responses', "
+        "then set answer['content'] = responses and answer['ready'] = True."
     )
 
     print("Prompt:", prompt)

--- a/rlm/core/rlm.py
+++ b/rlm/core/rlm.py
@@ -26,7 +26,6 @@ from rlm.utils.exceptions import (
 )
 from rlm.utils.parsing import (
     find_code_blocks,
-    find_final_answer,
     format_iteration,
 )
 from rlm.utils.prompts import (
@@ -351,17 +350,14 @@ class RLM:
                     # Check error/budget/token limits after each iteration
                     self._check_iteration_limits(iteration, i, lm_handler)
 
-                    # Check if RLM is done and has a final answer.
-                    # Prefer FINAL_VAR result from REPL execution.
+                    # The REPL signals completion by populating
+                    # ``answer["content"]`` and setting ``answer["ready"] = True``.
+                    # Each environment surfaces that on ``REPLResult.final_answer``.
                     final_answer = None
                     for block in iteration.code_blocks:
-                        if getattr(block.result, "final_answer", None):
+                        if getattr(block.result, "final_answer", None) is not None:
                             final_answer = block.result.final_answer
                             break
-                    if final_answer is None:
-                        final_answer = find_final_answer(
-                            iteration.response, environment=environment
-                        )
                     iteration.final_answer = final_answer
 
                     # Store as best partial answer (most recent response with content)

--- a/rlm/environments/base_env.py
+++ b/rlm/environments/base_env.py
@@ -16,8 +16,8 @@ RESERVED_TOOL_NAMES: frozenset[str] = frozenset(
         "llm_query_batched",
         "rlm_query",
         "rlm_query_batched",
-        "FINAL_VAR",
         "SHOW_VARS",
+        "answer",
         "context",
         "history",
     }
@@ -176,7 +176,8 @@ class SupportsCustomTools(Protocol):
         The following names cannot be used as custom tool names:
         - llm_query, llm_query_batched: Single LM completion functions (no tool access)
         - rlm_query, rlm_query_batched: Recursive RLM calls for deeper thinking subtasks
-        - FINAL_VAR, SHOW_VARS: Built-in helper functions
+        - SHOW_VARS: Built-in helper for listing REPL variables
+        - answer: The final-answer dict ({"content": ..., "ready": False})
         - context, history: The input context and conversation history variables
 
     EXAMPLE:

--- a/rlm/environments/daytona_repl.py
+++ b/rlm/environments/daytona_repl.py
@@ -300,17 +300,11 @@ def serialize_locals(state):
 
 _locals = load_state()
 
-def FINAL_VAR(variable_name):
-    variable_name = variable_name.strip().strip("\\"\\'")
-    if variable_name in _locals:
-        return str(_locals[variable_name])
-    available = [k for k in _locals.keys() if not k.startswith("_")]
-    if available:
-        return f"Error: Variable '{{variable_name}}' not found. Available variables: {{available}}. You must create and assign a variable BEFORE calling FINAL_VAR on it."
-    return f"Error: Variable '{{variable_name}}' not found. No variables have been created yet. You must create and assign a variable in a REPL block BEFORE calling FINAL_VAR on it."
+if "answer" not in _locals or not isinstance(_locals.get("answer"), dict):
+    _locals["answer"] = {{"content": "", "ready": False}}
 
 def SHOW_VARS():
-    available = {{k: type(v).__name__ for k, v in _locals.items() if not k.startswith("_")}}
+    available = {{k: type(v).__name__ for k, v in _locals.items() if not k.startswith("_") and k != "answer"}}
     if not available:
         return "No variables created yet. Use ```repl``` blocks to create variables."
     return f"Available variables: {{available}}"
@@ -320,7 +314,6 @@ _globals = {{
     "__name__": "__main__",
     "llm_query": llm_query,
     "llm_query_batched": llm_query_batched,
-    "FINAL_VAR": FINAL_VAR,
     "SHOW_VARS": SHOW_VARS,
 }}
 
@@ -357,10 +350,13 @@ if "history_0" in _locals:
 
 save_state(_locals)
 
+_ans = _locals.get("answer") if isinstance(_locals.get("answer"), dict) else None
+_final = str(_ans.get("content", "")) if (_ans is not None and _ans.get("ready")) else None
 result = {{
     "stdout": stdout_buf.getvalue(),
     "stderr": stderr_buf.getvalue(),
     "locals": serialize_locals(_locals),
+    "final_answer": _final,
 }}
 print(json.dumps(result))
 '''
@@ -665,6 +661,7 @@ class DaytonaREPL(IsolatedEnv):
                 locals=result.get("locals", {}),
                 execution_time=execution_time,
                 rlm_calls=pending_calls,
+                final_answer=result.get("final_answer"),
             )
         except json.JSONDecodeError:
             return REPLResult(

--- a/rlm/environments/docker_repl.py
+++ b/rlm/environments/docker_repl.py
@@ -140,22 +140,17 @@ def save_state(s):
 
 _locals = load_state()
 
-def FINAL_VAR(name):
-    name = name.strip().strip("\\"\\'")
-    if name in _locals:
-        return str(_locals[name])
-    available = [k for k in _locals.keys() if not k.startswith("_")]
-    if available:
-        return f"Error: Variable '{{name}}' not found. Available variables: {{available}}. You must create and assign a variable BEFORE calling FINAL_VAR on it."
-    return f"Error: Variable '{{name}}' not found. No variables have been created yet. You must create and assign a variable in a REPL block BEFORE calling FINAL_VAR on it."
+# Default answer dict on the first invocation; preserved across calls via state.
+if "answer" not in _locals or not isinstance(_locals.get("answer"), dict):
+    _locals["answer"] = {{"content": "", "ready": False}}
 
 def SHOW_VARS():
-    available = {{k: type(v).__name__ for k, v in _locals.items() if not k.startswith("_")}}
+    available = {{k: type(v).__name__ for k, v in _locals.items() if not k.startswith("_") and k != "answer"}}
     if not available:
         return "No variables created yet. Use ```repl``` blocks to create variables."
     return f"Available variables: {{available}}"
 
-_globals = {{"__builtins__": __builtins__, "__name__": "__main__", "llm_query": llm_query, "llm_query_batched": llm_query_batched, "FINAL_VAR": FINAL_VAR, "SHOW_VARS": SHOW_VARS}}
+_globals = {{"__builtins__": __builtins__, "__name__": "__main__", "llm_query": llm_query, "llm_query_batched": llm_query_batched, "SHOW_VARS": SHOW_VARS}}
 
 code = base64.b64decode("{code_b64}").decode()
 stdout_buf, stderr_buf = io.StringIO(), io.StringIO()
@@ -180,7 +175,11 @@ if "history_0" in _locals:
     _locals["history"] = _locals["history_0"]
 
 save_state(_locals)
-print(json.dumps({{"stdout": stdout_buf.getvalue(), "stderr": stderr_buf.getvalue(), "locals": {{k: repr(v) for k, v in _locals.items() if not k.startswith("_")}}}}, ensure_ascii=False))
+_ans = _locals.get("answer") if isinstance(_locals.get("answer"), dict) else None
+_final = None
+if _ans is not None and _ans.get("ready"):
+    _final = str(_ans.get("content", ""))
+print(json.dumps({{"stdout": stdout_buf.getvalue(), "stderr": stderr_buf.getvalue(), "locals": {{k: repr(v) for k, v in _locals.items() if not k.startswith("_")}}, "final_answer": _final}}, ensure_ascii=False))
 '''
     )
 
@@ -320,6 +319,7 @@ class DockerREPL(NonIsolatedEnv):
                 locals=data.get("locals", {}),
                 execution_time=time.perf_counter() - start,
                 rlm_calls=calls,
+                final_answer=data.get("final_answer"),
             )
         except json.JSONDecodeError:
             return REPLResult(

--- a/rlm/environments/e2b_repl.py
+++ b/rlm/environments/e2b_repl.py
@@ -207,18 +207,14 @@ def serialize_locals(state):
 
 _locals = load_state()
 
-def FINAL_VAR(variable_name):
-    variable_name = variable_name.strip().strip("\\"\\'")
-    if variable_name in _locals:
-        return str(_locals[variable_name])
-    return f"Error: Variable '{{variable_name}}' not found"
+if "answer" not in _locals or not isinstance(_locals.get("answer"), dict):
+    _locals["answer"] = {{"content": "", "ready": False}}
 
 _globals = {{
     "__builtins__": __builtins__,
     "__name__": "__main__",
     "llm_query": llm_query,
     "llm_query_batched": llm_query_batched,
-    "FINAL_VAR": FINAL_VAR,
 }}
 
 code = base64.b64decode("{code_b64}").decode()
@@ -249,10 +245,13 @@ if "history_0" in _locals:
 
 save_state(_locals)
 
+_ans = _locals.get("answer") if isinstance(_locals.get("answer"), dict) else None
+_final = str(_ans.get("content", "")) if (_ans is not None and _ans.get("ready")) else None
 result = {{
     "stdout": stdout_buf.getvalue(),
     "stderr": stderr_buf.getvalue(),
     "locals": serialize_locals(_locals),
+    "final_answer": _final,
 }}
 print(json.dumps(result))
 '''
@@ -475,6 +474,7 @@ class E2BREPL(IsolatedEnv):
                 locals=parsed.get("locals", {}),
                 execution_time=execution_time,
                 rlm_calls=pending_calls,
+                final_answer=parsed.get("final_answer"),
             )
         except json.JSONDecodeError:
             return REPLResult(

--- a/rlm/environments/ipython_repl.py
+++ b/rlm/environments/ipython_repl.py
@@ -52,6 +52,7 @@ from rlm.environments.base_env import (
     extract_tool_value,
     validate_custom_tools,
 )
+from rlm.environments.local_repl import _AnswerDict
 
 KernelMode = Literal["in_process", "subprocess"]
 
@@ -97,21 +98,21 @@ _ANSI_RE = re.compile(
 
 class _SubcallBroker:
     """TCP broker that the subprocess kernel calls back into for rlm_query
-    and FINAL_VAR results.
+    and final-answer results.
 
     Reuses the 4-byte-length-prefix JSON protocol from ``rlm.core.comms_utils``.
 
-    Request types (all subcall/final_var requests carry a ``cell_id`` so
-    the parent can attribute completions to the cell that triggered them
-    even if ``subcall_fn`` finishes after that cell has timed out):
+    Request types (all carry a ``cell_id`` so the parent can attribute
+    completions / final answers to the cell that triggered them even if
+    ``subcall_fn`` finishes after that cell has timed out):
         {"type": "subcall", "prompt": str, "model": str | None, "cell_id": str}
         {"type": "subcall_batched", "prompts": [str], "model": str | None, "cell_id": str}
-        {"type": "final_var", "value": str, "cell_id": str}
+        {"type": "answer", "content": str, "cell_id": str}
 
     Responses:
         subcall:          {"completion": RLMChatCompletion.to_dict()} | {"error": str}
         subcall_batched:  {"responses": [str]}                        | {"error": str}
-        final_var:        {"ok": True}
+        answer:           {"ok": True}
     """
 
     def __init__(
@@ -193,10 +194,10 @@ class _SubcallBroker:
 
         cell_id = data.get("cell_id") or ""
 
-        if req_type == "final_var":
-            value = data.get("value")
+        if req_type == "answer":
+            content = data.get("content")
             with self._lock:
-                self._final_answers_by_cell[cell_id] = str(value) if value is not None else ""
+                self._final_answers_by_cell[cell_id] = str(content) if content is not None else ""
             return {"ok": True}
 
         if req_type == "subcall":
@@ -321,7 +322,7 @@ def _build_kernel_bootstrap(
         _RLM_DEPTH = {depth}
         _RLM_SUBCALL_TIMEOUT = {subcall_timeout!r}
         # Updated by the parent before each user cell. Tagged onto every
-        # broker request so completions / FINAL_VAR answers can be
+        # broker request so completions / answer-dict captures can be
         # attributed to the cell that originated them.
         _RLM_CURRENT_CELL = ""
 
@@ -415,43 +416,28 @@ def _build_kernel_bootstrap(
                 return [f"Error: {{resp['error']}}"] * len(prompts)
             return list(resp.get("responses") or [])
 
-        def FINAL_VAR(variable):
-            if not isinstance(variable, str):
-                answer = str(variable)
-                _rlm_request(_RLM_SUBCALL_ADDRESS, {{
-                    "type": "final_var", "value": answer,
-                    "cell_id": _RLM_CURRENT_CELL,
-                }})
-                return answer
-            name = variable.strip().strip('"\\'')
-            ns = get_ipython().user_ns
-            if name in ns:
-                answer = str(ns[name])
-                _rlm_request(_RLM_SUBCALL_ADDRESS, {{
-                    "type": "final_var", "value": answer,
-                    "cell_id": _RLM_CURRENT_CELL,
-                }})
-                return answer
-            skip = {{"In", "Out", "exit", "quit", "get_ipython"}}
-            available = [
-                k for k in ns.keys()
-                if not k.startswith("_") and k not in skip
-            ]
-            if available:
-                return (
-                    f"Error: Variable {{name!r}} not found. "
-                    f"Available variables: {{available}}. "
-                    "You must create and assign a variable BEFORE calling FINAL_VAR on it."
-                )
-            return (
-                f"Error: Variable {{name!r}} not found. "
-                "No variables have been created yet. "
-                "You must create and assign a variable in a REPL block BEFORE calling FINAL_VAR on it."
-            )
+        class _RLMAnswerDict(dict):
+            def __init__(self):
+                super().__init__()
+                dict.__setitem__(self, "content", "")
+                dict.__setitem__(self, "ready", False)
+            def __setitem__(self, key, value):
+                dict.__setitem__(self, key, value)
+                if key == "ready" and value:
+                    try:
+                        _rlm_request(_RLM_SUBCALL_ADDRESS, {{
+                            "type": "answer",
+                            "content": str(self.get("content", "")),
+                            "cell_id": _RLM_CURRENT_CELL,
+                        }})
+                    except Exception:
+                        pass
+
+        answer = _RLMAnswerDict()
 
         def SHOW_VARS():
             ns = get_ipython().user_ns
-            skip = {{"In", "Out", "exit", "quit", "get_ipython"}}
+            skip = {{"In", "Out", "exit", "quit", "get_ipython", "answer"}}
             available = {{
                 k: type(v).__name__
                 for k, v in ns.items()
@@ -491,7 +477,7 @@ class IPythonREPL(NonIsolatedEnv):
           namespace, cwd, and signals.
 
     Subcall attribution caveat (subprocess mode):
-        Subcall completions and FINAL_VAR answers are tagged with the
+        Subcall completions and final-answer captures are tagged with the
         ``cell_id`` that was active *at the moment the kernel issued the
         request*. If a cell spawns long-lived kernel-side state (a
         ``threading.Thread``, an ``asyncio.Task`` left running, a
@@ -524,10 +510,10 @@ class IPythonREPL(NonIsolatedEnv):
         startup_timeout: Max seconds to wait for a ``subprocess`` kernel to
             become ready.
         subcall_timeout: Per-request timeout (seconds) for the kernel→parent
-            socket round-trip used by ``llm_query`` / ``rlm_query`` /
-            ``FINAL_VAR`` in subprocess mode. ``None`` (default) disables
-            the timeout, which matches in-process behavior where subcalls
-            block indefinitely.
+            socket round-trip used by ``llm_query`` / ``rlm_query`` and the
+            answer-dict broker push in subprocess mode. ``None`` (default)
+            disables the timeout, which matches in-process behavior where
+            subcalls block indefinitely.
         max_concurrent_subcalls: Cap on concurrent ``rlm_query_batched`` calls.
     """
 
@@ -716,9 +702,9 @@ class IPythonREPL(NonIsolatedEnv):
         ns["llm_query_batched"] = self._llm_query_batched
         ns["rlm_query"] = self._rlm_query
         ns["rlm_query_batched"] = self._rlm_query_batched
-        ns["FINAL_VAR"] = self._final_var
         ns["SHOW_VARS"] = self._show_vars
         ns["input"] = self._disabled_input
+        ns["answer"] = _AnswerDict(on_ready=self._capture_answer)
 
         # Inject custom tools
         for name, entry in self.custom_tools.items():
@@ -845,31 +831,9 @@ class IPythonREPL(NonIsolatedEnv):
     # Scaffold helpers (in-process only; subprocess has its own in the kernel)
     # -------------------------------------------------------------------------
 
-    def _final_var(self, variable_name: str | Any) -> str:
-        if not isinstance(variable_name, str):
-            answer = str(variable_name)
-            self._last_final_answer = answer
-            return answer
-        name = variable_name.strip().strip("\"'")
-        ns = self._shell.user_ns if self._shell is not None else {}
-        if name in ns:
-            answer = str(ns[name])
-            self._last_final_answer = answer
-            return answer
-        available = [
-            k for k in ns.keys() if not k.startswith("_") and k not in _IPYTHON_INTERNAL_NAMES
-        ]
-        if available:
-            return (
-                f"Error: Variable '{name}' not found. "
-                f"Available variables: {available}. "
-                f"You must create and assign a variable BEFORE calling FINAL_VAR on it."
-            )
-        return (
-            f"Error: Variable '{name}' not found. "
-            f"No variables have been created yet. "
-            f"You must create and assign a variable in a REPL block BEFORE calling FINAL_VAR on it."
-        )
+    def _capture_answer(self, content: Any) -> None:
+        """Called by ``_AnswerDict`` when the model sets ``answer["ready"] = True``."""
+        self._last_final_answer = str(content)
 
     @staticmethod
     def _disabled_input(*_args: Any, **_kwargs: Any) -> str:
@@ -889,7 +853,7 @@ class IPythonREPL(NonIsolatedEnv):
         available = {
             k: type(v).__name__
             for k, v in ns.items()
-            if not k.startswith("_") and k not in _IPYTHON_INTERNAL_NAMES
+            if not k.startswith("_") and k not in _IPYTHON_INTERNAL_NAMES and k != "answer"
         }
         if not available:
             return "No variables created yet. Use ```repl``` blocks to create variables."
@@ -1305,7 +1269,7 @@ class IPythonREPL(NonIsolatedEnv):
         start_time = time.perf_counter()
 
         # Generate a unique cell_id so the broker can attribute every
-        # subcall completion / FINAL_VAR answer to *this* cell. A subcall
+        # subcall completion / answer-dict capture to *this* cell. A subcall
         # whose ``subcall_fn`` finishes after this cell times out will
         # land under this id and stay there until the next drain (which
         # discards it as stale).
@@ -1391,7 +1355,7 @@ class IPythonREPL(NonIsolatedEnv):
             else:
                 stderr_parts.append(f"\n{ename}: {evalue}")
 
-        # Drain broker state (rlm_query completions, FINAL_VAR answer)
+        # Drain broker state (rlm_query completions, answer-dict capture)
         # *for this cell only*. Stragglers from prior timed-out cells live
         # under their own cell_id; ``drain(cell_id)`` discards them rather
         # than attributing them to this cell.
@@ -1422,9 +1386,19 @@ class IPythonREPL(NonIsolatedEnv):
         ns["llm_query_batched"] = self._llm_query_batched
         ns["rlm_query"] = self._rlm_query
         ns["rlm_query_batched"] = self._rlm_query_batched
-        ns["FINAL_VAR"] = self._final_var
         ns["SHOW_VARS"] = self._show_vars
         ns["input"] = self._disabled_input
+        # Rewrap ``answer`` if the user rebound it to a plain dict, so
+        # subsequent ``ready=True`` assignments still trigger capture.
+        current = ns.get("answer")
+        if not isinstance(current, _AnswerDict):
+            replacement = _AnswerDict(on_ready=self._capture_answer)
+            if isinstance(current, dict):
+                for k, v in current.items():
+                    dict.__setitem__(replacement, k, v)
+                if current.get("ready") and self._last_final_answer is None:
+                    self._last_final_answer = str(current.get("content", ""))
+            ns["answer"] = replacement
         if "context_0" in ns:
             ns["context"] = ns["context_0"]
         if "history_0" in ns:

--- a/rlm/environments/local_repl.py
+++ b/rlm/environments/local_repl.py
@@ -22,6 +22,31 @@ from rlm.environments.base_env import (
     validate_custom_tools,
 )
 
+
+class _AnswerDict(dict):
+    """REPL-visible dict where ``answer["ready"] = True`` signals completion.
+
+    Behaves exactly like ``dict`` for the model, but invokes ``on_ready`` the
+    first time ``ready`` flips truthy. The callback receives the current
+    ``content``, lets the env capture it (in-process attr, broker push, etc.),
+    and the next ``execute_code`` will surface it as ``REPLResult.final_answer``.
+    """
+
+    def __init__(self, on_ready=None):
+        super().__init__()
+        super().__setitem__("content", "")
+        super().__setitem__("ready", False)
+        self._on_ready = on_ready
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        if key == "ready" and value and self._on_ready is not None:
+            try:
+                self._on_ready(self.get("content", ""))
+            except Exception:
+                pass
+
+
 # =============================================================================
 # Safe Builtins
 # =============================================================================
@@ -191,16 +216,20 @@ class LocalREPL(NonIsolatedEnv):
 
         # Track LLM calls made during code execution
         self._pending_llm_calls: list[RLMChatCompletion] = []
-        # When FINAL_VAR is called inside a REPL block, we store the value here for the main loop
+        # Captured the first time the model sets ``answer["ready"] = True``.
         self._last_final_answer: str | None = None
 
         # Add helper functions
-        self.globals["FINAL_VAR"] = self._final_var
         self.globals["SHOW_VARS"] = self._show_vars
         self.globals["llm_query"] = self._llm_query
         self.globals["llm_query_batched"] = self._llm_query_batched
         self.globals["rlm_query"] = self._rlm_query
         self.globals["rlm_query_batched"] = self._rlm_query_batched
+
+        # The model marks completion via ``answer["ready"] = True``; the
+        # custom dict captures the content as soon as that happens so we
+        # don't have to probe the namespace after every cell.
+        self.locals["answer"] = _AnswerDict(on_ready=self._capture_answer)
 
         # Add custom tools to globals
         # Tools can be either plain values or (value, description) tuples
@@ -212,35 +241,16 @@ class LocalREPL(NonIsolatedEnv):
                 # For non-callable values (constants, data), add to locals
                 self.locals[name] = value
 
-    def _final_var(self, variable_name: str | Any) -> str:
-        """Return the value of a variable as a final answer for the main model, or stringify a direct value."""
-        if not isinstance(variable_name, str):
-            answer = str(variable_name)
-            self._last_final_answer = answer
-            return answer
-        variable_name = variable_name.strip().strip("\"'")
-        if variable_name in self.locals:
-            answer = str(self.locals[variable_name])
-            self._last_final_answer = answer
-            return answer
-
-        # Provide helpful error message with available variables (do not set _last_final_answer)
-        available = [k for k in self.locals.keys() if not k.startswith("_")]
-        if available:
-            return (
-                f"Error: Variable '{variable_name}' not found. "
-                f"Available variables: {available}. "
-                f"You must create and assign a variable BEFORE calling FINAL_VAR on it."
-            )
-        return (
-            f"Error: Variable '{variable_name}' not found. "
-            f"No variables have been created yet. "
-            f"You must create and assign a variable in a REPL block BEFORE calling FINAL_VAR on it."
-        )
+    def _capture_answer(self, content: Any) -> None:
+        self._last_final_answer = str(content)
 
     def _show_vars(self) -> str:
         """Show all available variables in the REPL environment."""
-        available = {k: type(v).__name__ for k, v in self.locals.items() if not k.startswith("_")}
+        available = {
+            k: type(v).__name__
+            for k, v in self.locals.items()
+            if not k.startswith("_") and k != "answer"
+        }
         if not available:
             return "No variables created yet. Use ```repl``` blocks to create variables."
         return f"Available variables: {available}"
@@ -512,10 +522,21 @@ class LocalREPL(NonIsolatedEnv):
                 self.globals["rlm_query"] = self._rlm_query
             elif name == "rlm_query_batched":
                 self.globals["rlm_query_batched"] = self._rlm_query_batched
-            elif name == "FINAL_VAR":
-                self.globals["FINAL_VAR"] = self._final_var
             elif name == "SHOW_VARS":
                 self.globals["SHOW_VARS"] = self._show_vars
+            elif name == "answer":
+                current = self.locals.get("answer")
+                # If the model rebound ``answer`` to a plain dict, the
+                # _AnswerDict callback never fired; capture content here if
+                # ``ready=True``, then re-wrap so the next cell signals.
+                if not isinstance(current, _AnswerDict):
+                    replacement = _AnswerDict(on_ready=self._capture_answer)
+                    if isinstance(current, dict):
+                        for k, v in current.items():
+                            dict.__setitem__(replacement, k, v)
+                        if current.get("ready") and self._last_final_answer is None:
+                            self._last_final_answer = str(current.get("content", ""))
+                    self.locals["answer"] = replacement
             elif name == "context" and "context_0" in self.locals:
                 self.locals["context"] = self.locals["context_0"]
             elif name == "history" and "history_0" in self.locals and not self.compaction:

--- a/rlm/environments/modal_repl.py
+++ b/rlm/environments/modal_repl.py
@@ -217,17 +217,11 @@ def serialize_locals(state):
 
 _locals = load_state()
 
-def FINAL_VAR(variable_name):
-    variable_name = variable_name.strip().strip("\\"\\'")
-    if variable_name in _locals:
-        return str(_locals[variable_name])
-    available = [k for k in _locals.keys() if not k.startswith("_")]
-    if available:
-        return f"Error: Variable '{{variable_name}}' not found. Available variables: {{available}}. You must create and assign a variable BEFORE calling FINAL_VAR on it."
-    return f"Error: Variable '{{variable_name}}' not found. No variables have been created yet. You must create and assign a variable in a REPL block BEFORE calling FINAL_VAR on it."
+if "answer" not in _locals or not isinstance(_locals.get("answer"), dict):
+    _locals["answer"] = {{"content": "", "ready": False}}
 
 def SHOW_VARS():
-    available = {{k: type(v).__name__ for k, v in _locals.items() if not k.startswith("_")}}
+    available = {{k: type(v).__name__ for k, v in _locals.items() if not k.startswith("_") and k != "answer"}}
     if not available:
         return "No variables created yet. Use ```repl``` blocks to create variables."
     return f"Available variables: {{available}}"
@@ -237,7 +231,6 @@ _globals = {{
     "__name__": "__main__",
     "llm_query": llm_query,
     "llm_query_batched": llm_query_batched,
-    "FINAL_VAR": FINAL_VAR,
     "SHOW_VARS": SHOW_VARS,
 }}
 
@@ -269,10 +262,13 @@ if "history_0" in _locals:
 
 save_state(_locals)
 
+_ans = _locals.get("answer") if isinstance(_locals.get("answer"), dict) else None
+_final = str(_ans.get("content", "")) if (_ans is not None and _ans.get("ready")) else None
 result = {{
     "stdout": stdout_buf.getvalue(),
     "stderr": stderr_buf.getvalue(),
     "locals": serialize_locals(_locals),
+    "final_answer": _final,
 }}
 print(json.dumps(result))
 '''
@@ -482,6 +478,7 @@ class ModalREPL(IsolatedEnv):
                 locals=result.get("locals", {}),
                 execution_time=execution_time,
                 rlm_calls=pending_calls,
+                final_answer=result.get("final_answer"),
             )
         except json.JSONDecodeError:
             return REPLResult(

--- a/rlm/environments/prime_repl.py
+++ b/rlm/environments/prime_repl.py
@@ -216,17 +216,11 @@ def serialize_locals(state):
 
 _locals = load_state()
 
-def FINAL_VAR(variable_name):
-    variable_name = variable_name.strip().strip("\\"\\'")
-    if variable_name in _locals:
-        return str(_locals[variable_name])
-    available = [k for k in _locals.keys() if not k.startswith("_")]
-    if available:
-        return f"Error: Variable '{{variable_name}}' not found. Available variables: {{available}}. You must create and assign a variable BEFORE calling FINAL_VAR on it."
-    return f"Error: Variable '{{variable_name}}' not found. No variables have been created yet. You must create and assign a variable in a REPL block BEFORE calling FINAL_VAR on it."
+if "answer" not in _locals or not isinstance(_locals.get("answer"), dict):
+    _locals["answer"] = {{"content": "", "ready": False}}
 
 def SHOW_VARS():
-    available = {{k: type(v).__name__ for k, v in _locals.items() if not k.startswith("_")}}
+    available = {{k: type(v).__name__ for k, v in _locals.items() if not k.startswith("_") and k != "answer"}}
     if not available:
         return "No variables created yet. Use ```repl``` blocks to create variables."
     return f"Available variables: {{available}}"
@@ -236,7 +230,6 @@ _globals = {{
     "__name__": "__main__",
     "llm_query": llm_query,
     "llm_query_batched": llm_query_batched,
-    "FINAL_VAR": FINAL_VAR,
     "SHOW_VARS": SHOW_VARS,
 }}
 
@@ -268,10 +261,13 @@ if "history_0" in _locals:
 
 save_state(_locals)
 
+_ans = _locals.get("answer") if isinstance(_locals.get("answer"), dict) else None
+_final = str(_ans.get("content", "")) if (_ans is not None and _ans.get("ready")) else None
 result = {{
     "stdout": stdout_buf.getvalue(),
     "stderr": stderr_buf.getvalue(),
     "locals": serialize_locals(_locals),
+    "final_answer": _final,
 }}
 print(json.dumps(result))
 '''
@@ -556,6 +552,7 @@ class PrimeREPL(IsolatedEnv):
                 locals=parsed.get("locals", {}),
                 execution_time=execution_time,
                 rlm_calls=pending_calls,
+                final_answer=parsed.get("final_answer"),
             )
         except json.JSONDecodeError:
             return REPLResult(

--- a/rlm/utils/parsing.py
+++ b/rlm/utils/parsing.py
@@ -3,12 +3,8 @@ Parsing utilities for RLM trjaectories.
 """
 
 import re
-from typing import TYPE_CHECKING
 
 from rlm.core.types import REPLResult, RLMIteration
-
-if TYPE_CHECKING:
-    from rlm.environments.base_env import BaseEnv
 
 
 def find_code_blocks(text: str) -> list[str]:
@@ -24,50 +20,6 @@ def find_code_blocks(text: str) -> list[str]:
         results.append(code_content)
 
     return results
-
-
-def find_final_answer(text: str, environment: "BaseEnv | None" = None) -> str | None:
-    """
-    Find FINAL(...) or FINAL_VAR(...) statement in response and return the final answer string.
-
-    If FINAL_VAR is found and an environment is provided, executes code to retrieve the variable value.
-    Returns None if neither pattern is found.
-
-    Args:
-        text: The response text to parse
-        environment: Optional environment to execute code for FINAL_VAR retrieval
-
-    Returns:
-        The final answer string, or None if no final answer pattern is found
-    """
-    # Check for FINAL_VAR pattern first - must be at start of line
-    final_var_pattern = r"^\s*FINAL_VAR\((.*?)\)"
-    match = re.search(final_var_pattern, text, re.MULTILINE | re.DOTALL)
-    if match:
-        variable_name = match.group(1).strip().strip('"').strip("'")
-        if environment is not None:
-            result = environment.execute_code(f"print(FINAL_VAR({variable_name!r}))")
-            final_answer = result.stdout.strip()
-            if final_answer == "":
-                return None
-            # Don't treat FINAL_VAR "variable not found" as final answer (so RLM continues)
-            if (
-                "Variable '" in final_answer
-                and "' not found" in final_answer
-                and "FINAL_VAR" in final_answer
-            ):
-                return None
-            return final_answer
-        return None
-
-    # Check for FINAL pattern - must be at start of line
-    # Use greedy matching to capture content with nested parentheses
-    final_pattern = r"^\s*FINAL\((.*)\)\s*$"
-    match = re.search(final_pattern, text, re.MULTILINE | re.DOTALL)
-    if match:
-        return match.group(1).strip()
-
-    return None
 
 
 def format_iteration(
@@ -141,12 +93,6 @@ def format_execution_result(result: REPLResult) -> str:
         result_parts.append(f"REPL variables: {list(important_vars.keys())}\n")
 
     return "\n\n".join(result_parts) if result_parts else "No output"
-
-
-def check_for_final_answer(response: str, repl_env, logger) -> str | None:
-    """Check if response contains a final answer."""
-    # Use the new find_final_answer function which handles both FINAL and FINAL_VAR
-    return find_final_answer(response, environment=repl_env)
 
 
 def convert_context_for_repl(context):

--- a/rlm/utils/prompts.py
+++ b/rlm/utils/prompts.py
@@ -13,8 +13,9 @@ The REPL environment is initialized with:
 3. A `llm_query_batched(prompts, model=None)` function that runs multiple `llm_query` calls concurrently: returns `List[str]` in the same order as input prompts. Much faster than sequential `llm_query` calls for independent queries.
 4. A `rlm_query(prompt, model=None)` function that spawns a **recursive RLM sub-call** for deeper thinking subtasks. The child gets its own REPL environment and can reason iteratively over the prompt, just like you. Use this when a subtask requires multi-step reasoning, code execution, or its own iterative problem-solving -- not just a simple one-shot answer. Falls back to `llm_query` if recursion is not available.
 5. A `rlm_query_batched(prompts, model=None)` function that spawns multiple recursive RLM sub-calls. Each prompt gets its own child RLM. Falls back to `llm_query_batched` if recursion is not available.
-6. A `SHOW_VARS()` function that returns all variables you have created in the REPL. Use this to check what variables exist before using FINAL_VAR.
+6. A `SHOW_VARS()` function that returns all variables you have created in the REPL. Use this to check what variables exist.
 7. The ability to use `print()` statements to view the output of your REPL code and continue your reasoning.
+8. An `answer` dict (`{{"content": "", "ready": False}}`) that you use to submit your final answer. See "Submitting your final answer" below.
 {custom_tools_section}
 
 **When to use `llm_query` vs `rlm_query`:**
@@ -32,7 +33,7 @@ v_parallel = pitch * (q * B) / (2 * math.pi * m)
 v_perp = R * (q * B) / m
 theta_rad = math.atan2(v_perp, v_parallel)
 theta_deg = math.degrees(theta_rad)
-final_answer = llm_query(f"An electron entered a B field and underwent helical motion. Computed entry angle: {{theta_deg:.2f}} deg. State the answer clearly for the user.")
+summary = llm_query(f"An electron entered a B field and underwent helical motion. Computed entry angle: {{theta_deg:.2f}} deg. State the answer clearly for the user.")
 ```
 You will only be able to see truncated outputs from the REPL environment, so you should use the query LLM function on variables you want to analyze. You will find this function especially useful when you have to analyze the semantics of the context. Use these variables as buffers to build up your final answer.
 Make sure to explicitly look through the entire context in REPL before answering your query. Break the context and the problem into digestible pieces: e.g. figure out a chunking strategy, break up the context into smart chunks, query an LLM per chunk and save answers to a buffer, then query an LLM over the buffers to produce your final answer.
@@ -76,7 +77,7 @@ prompts = [f"Try to answer the following query: {{query}}. Here are the document
 answers = llm_query_batched(prompts)
 for i, answer in enumerate(answers):
     print(f"I got the answer from chunk {{i}}: {{answer}}")
-final_answer = llm_query(f"Aggregating all the answers per chunk, answer the original query about total number of jobs: {{query}}\\n\\nAnswers:\\n" + "\\n".join(answers))
+summary = llm_query(f"Aggregating all the answers per chunk, answer the original query about total number of jobs: {{query}}\\n\\nAnswers:\\n" + "\\n".join(answers))
 ```
 
 For subtasks that require deeper reasoning (e.g. solving a complex sub-problem), use `rlm_query` instead. The child gets its own REPL to iterate; you can then use the result in parent logic:
@@ -89,25 +90,22 @@ elif "down" in trend.lower():
     recommendation = "Consider hedging."
 else:
     recommendation = "Hold position."
-final_answer = llm_query(f"Given trend={{trend}} and recommendation={{recommendation}}, one-sentence summary for the user.")
+summary = llm_query(f"Given trend={{trend}} and recommendation={{recommendation}}, one-sentence summary for the user.")
 ```
 
 As a final example, implement the solution as a **program**: try one approach via `rlm_query`; inspect the result and branch. If it suffices, use it. If not, break into one easier subproblem and delegate that only. More branches, one path runs—don't load the model. Example: prove sqrt 2 irrational.
 ```repl
 r = rlm_query("Prove sqrt 2 is irrational. Give a 1-2 sentence proof, or reply only: USE_LEMMA or USE_CONTRADICTION.")
 if "USE_LEMMA" in r.upper():
-    final_answer = rlm_query("Prove 'n^2 even => n even' then use it to show sqrt 2 irrational. Two sentences.")
+    summary = rlm_query("Prove 'n^2 even => n even' then use it to show sqrt 2 irrational. Two sentences.")
 
-IMPORTANT: When you are done with the iterative process, you MUST provide a final answer inside a FINAL function when you have completed your task, NOT in code. Do not use these tags unless you have completed your task. You have two options:
-1. Use FINAL(your final answer here) to provide the answer directly
-2. Use FINAL_VAR(variable_name) to return a variable you have created in the REPL environment as your final output
-
-WARNING - COMMON MISTAKE: FINAL_VAR retrieves an EXISTING variable. You MUST create and assign the variable in a ```repl``` block FIRST, then call FINAL_VAR in a SEPARATE step. For example:
-- WRONG: Calling FINAL_VAR(my_answer) without first creating `my_answer` in a repl block
-- CORRECT: First run ```repl
-my_answer = "the result"
-print(my_answer)
-``` then in the NEXT response call FINAL_VAR(my_answer)
+Submitting your final answer:
+The REPL exposes an `answer` dict, initialized to `{{"content": "", "ready": False}}`. When (and only when) you are done with the task, submit your final answer from inside a ```repl``` block:
+```repl
+answer["content"] = "your final answer here"
+answer["ready"] = True
+```
+`answer["content"]` must hold the final answer text (it can be a string, number, or anything `str()`-able). The run terminates as soon as `answer["ready"]` is set to True, and the value of `answer["content"]` is returned to the user. Do NOT set `answer["ready"] = True` until you have actually completed the task. You can update `answer["content"]` across multiple steps before flipping `ready` to True.
 
 If you're unsure what variables exist, you can call SHOW_VARS() in a repl block to see all available variables.
 

--- a/tests/repl/test_custom_tools.py
+++ b/tests/repl/test_custom_tools.py
@@ -78,12 +78,12 @@ class TestValidateCustomTools:
 
     def test_multiple_reserved_names_all_reported(self):
         """When multiple reserved names are used, all should be reported."""
-        tools = {"llm_query": 1, "FINAL_VAR": 2, "valid_name": 3}
+        tools = {"llm_query": 1, "answer": 2, "valid_name": 3}
         with pytest.raises(ValueError) as exc_info:
             validate_custom_tools(tools)
         error_msg = str(exc_info.value)
         assert "llm_query" in error_msg
-        assert "FINAL_VAR" in error_msg
+        assert "answer" in error_msg
 
     def test_reserved_names_constant_is_frozen(self):
         """RESERVED_TOOL_NAMES should be immutable."""
@@ -187,14 +187,15 @@ class TestLocalREPLCustomTools:
         """Built-in REPL functions should still work with custom tools."""
         repl = LocalREPL(custom_tools=custom_tools)
 
-        # FINAL_VAR should still work
-        repl.execute_code("answer = double(21)")
-        result = repl.execute_code('print(FINAL_VAR("answer"))')
-        assert "42" in result.stdout
+        # The ``answer`` dict completion signal should still work alongside tools.
+        result = repl.execute_code('answer["content"] = double(21)\nanswer["ready"] = True')
+        assert result.final_answer == "42"
 
-        # SHOW_VARS should still work
+        # SHOW_VARS should still work (and skip the reserved ``answer`` slot).
+        repl.execute_code("my_var = 7")
         result = repl.execute_code("print(SHOW_VARS())")
-        assert "answer" in result.stdout
+        assert "my_var" in result.stdout
+        assert "answer" not in result.stdout
 
         repl.cleanup()
 

--- a/tests/test_depth_metadata.py
+++ b/tests/test_depth_metadata.py
@@ -36,6 +36,11 @@ def create_mock_lm(responses: list[str], model_name: str = "mock-model") -> Mock
     return mock
 
 
+def final(content: str) -> str:
+    """Render a model response that submits ``content`` as the final answer."""
+    return f"```repl\nanswer['content'] = {content!r}\nanswer['ready'] = True\n```"
+
+
 # ========================================================================
 # depth=1 tests: verify existing behavior is preserved
 # ========================================================================
@@ -45,9 +50,9 @@ class TestDepth1CompletionLoop:
     """Verify depth=1 completion loop works identically to before refactoring."""
 
     def test_basic_completion_with_final_answer(self):
-        """depth=1 RLM should complete normally with FINAL() answer."""
+        """depth=1 RLM should complete normally when the model sets answer['ready'] = True."""
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(42)"])
+            mock_lm = create_mock_lm([final("42")])
             mock_get_client.return_value = mock_lm
 
             rlm = RLM(
@@ -60,13 +65,13 @@ class TestDepth1CompletionLoop:
             assert result.root_model == "test-model"
 
     def test_multi_iteration_before_final(self):
-        """depth=1 should iterate multiple times before finding FINAL()."""
+        """depth=1 should iterate multiple times before the model signals ready."""
         with patch.object(rlm_module, "get_client") as mock_get_client:
             mock_lm = create_mock_lm(
                 [
                     "Let me think...\n```repl\nx = 1 + 1\nprint(x)\n```",
                     "Now I know.\n```repl\ny = x * 2\nprint(y)\n```",
-                    "FINAL(4)",
+                    final("4"),
                 ]
             )
             mock_get_client.return_value = mock_lm
@@ -82,7 +87,7 @@ class TestDepth1CompletionLoop:
     def test_no_subcall_fn_at_depth_1(self):
         """depth=1 (max_depth=1) should NOT pass subcall_fn to environment."""
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(done)"])
+            mock_lm = create_mock_lm([final("done")])
             mock_get_client.return_value = mock_lm
 
             rlm = RLM(
@@ -109,7 +114,7 @@ class TestDepth1CompletionLoop:
     def test_subcall_fn_passed_at_depth_gt_1(self):
         """max_depth>1 SHOULD pass subcall_fn to environment."""
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(done)"])
+            mock_lm = create_mock_lm([final("done")])
             mock_get_client.return_value = mock_lm
 
             rlm = RLM(
@@ -314,7 +319,7 @@ class TestDepth1LoggerMetadata:
     def test_completion_returns_metadata_with_logger(self):
         """When logger is provided, completion result should have metadata."""
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(42)"])
+            mock_lm = create_mock_lm([final("42")])
             mock_get_client.return_value = mock_lm
 
             logger = RLMLogger()
@@ -335,7 +340,7 @@ class TestDepth1LoggerMetadata:
     def test_completion_returns_no_metadata_without_logger(self):
         """When no logger is provided, metadata should be None."""
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(42)"])
+            mock_lm = create_mock_lm([final("42")])
             mock_get_client.return_value = mock_lm
 
             rlm = RLM(
@@ -353,7 +358,7 @@ class TestDepth1LoggerMetadata:
                 [
                     "Let me compute.\n```repl\nx = 1\n```",
                     "More work.\n```repl\ny = 2\n```",
-                    "FINAL(done)",
+                    final("done"),
                 ]
             )
             mock_get_client.return_value = mock_lm
@@ -391,7 +396,7 @@ class TestSubcallLoggerPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             logger = RLMLogger()
@@ -426,7 +431,7 @@ class TestSubcallLoggerPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -469,7 +474,7 @@ class TestSubcallLoggerPropagation:
         """When child RLM completes with a logger, the returned RLMChatCompletion should have metadata."""
         with patch.object(rlm_module, "get_client") as mock_get_client:
             # Need enough responses: parent init + child init + child completion
-            mock_lm = create_mock_lm(["FINAL(child answer)"] * 5, model_name="test-model")
+            mock_lm = create_mock_lm([final("child answer")] * 5, model_name="test-model")
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -506,7 +511,7 @@ class TestSubcallCustomToolsPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             my_tool = lambda x: x * 2  # noqa: E731
@@ -538,7 +543,7 @@ class TestSubcallCustomToolsPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -214,13 +214,11 @@ class TestUtilsImports:
         """Test parsing module import."""
         from rlm.utils.parsing import (
             find_code_blocks,
-            find_final_answer,
             format_execution_result,
             format_iteration,
         )
 
         assert callable(find_code_blocks)
-        assert callable(find_final_answer)
         assert callable(format_iteration)
         assert callable(format_execution_result)
 

--- a/tests/test_ipython_repl.py
+++ b/tests/test_ipython_repl.py
@@ -119,30 +119,28 @@ def test_in_process_exposes_locals_dict():
 
 
 # -----------------------------------------------------------------------------
-# FINAL_VAR
+# Final answer via the ``answer`` dict
 # -----------------------------------------------------------------------------
 
 
 @BOTH_MODES
-def test_final_var_returns_variable(kernel_mode: str):
+def test_answer_ready_surfaces_final_answer(kernel_mode: str):
     with IPythonREPL(kernel_mode=kernel_mode) as repl:
-        repl.execute_code("answer = 'forty-two'")
-        result = repl.execute_code('FINAL_VAR("answer")')
+        result = repl.execute_code('answer["content"] = "forty-two"\nanswer["ready"] = True')
     assert result.final_answer == "forty-two"
 
 
 @BOTH_MODES
-def test_final_var_missing_variable(kernel_mode: str):
+def test_answer_not_ready_returns_none(kernel_mode: str):
     with IPythonREPL(kernel_mode=kernel_mode) as repl:
-        result = repl.execute_code('FINAL_VAR("does_not_exist")')
+        result = repl.execute_code('answer["content"] = "wip"')
     assert result.final_answer is None
-    assert "not found" in result.stdout.lower() or "not found" in result.stderr.lower()
 
 
 @BOTH_MODES
-def test_final_var_accepts_direct_value(kernel_mode: str):
+def test_answer_content_is_stringified(kernel_mode: str):
     with IPythonREPL(kernel_mode=kernel_mode) as repl:
-        result = repl.execute_code("FINAL_VAR(123)")
+        result = repl.execute_code('answer["content"] = 123\nanswer["ready"] = True')
     assert result.final_answer == "123"
 
 
@@ -663,9 +661,9 @@ def test_stale_subcall_completion_not_misattributed_to_next_cell():
 
 
 @pytest.mark.skipif(not _has_subprocess, reason="jupyter_client not installed")
-def test_stale_final_var_not_misattributed_to_next_cell():
-    """Same logic for ``FINAL_VAR`` — a final-answer set by a prior cell's
-    delayed code path must not surface as the next cell's final answer."""
+def test_stale_final_answer_not_misattributed_to_next_cell():
+    """A final answer set by a prior cell's delayed code path must not
+    surface as the next cell's final answer."""
 
     barrier = threading.Event()
 
@@ -693,17 +691,16 @@ def test_stale_final_var_not_misattributed_to_next_cell():
         subcall_fn=slow_subcall,
         cell_timeout=0.1,
     ) as repl:
-        r1 = repl.execute_code('rlm_query("p"); FINAL_VAR("late-A")')
+        r1 = repl.execute_code(
+            'rlm_query("p")\nanswer["content"] = "late-A"\nanswer["ready"] = True'
+        )
         assert "TimeoutError" in r1.stderr
-        # Cell A is over with no FINAL_VAR captured.
+        # Cell A is over with no final answer captured.
         assert r1.final_answer is None
 
         # Now release subcall_fn and let it complete. If cell A's
-        # FINAL_VAR were globally stored (by old code), it would now be
+        # answer were globally stored (by old code), it would now be
         # in the broker waiting for the next drain to pick it up.
-        # (Note: in this test FINAL_VAR happens after rlm_query, which
-        # the timeout already prevented — but the same path is exercised
-        # by any straggler.)
         barrier.set()
         time.sleep(0.3)
 
@@ -711,7 +708,7 @@ def test_stale_final_var_not_misattributed_to_next_cell():
         r2 = repl.execute_code("print('clean')")
 
     assert r2.final_answer is None, (
-        f"cell B must not inherit cell A's stale FINAL_VAR; got {r2.final_answer!r}"
+        f"cell B must not inherit cell A's stale final answer; got {r2.final_answer!r}"
     )
 
 
@@ -731,7 +728,7 @@ def test_in_process_cell_cannot_reenter_via_scaffold_self():
     """
     with IPythonREPL(kernel_mode="in_process") as repl:
         # ``rlm_query`` is a bound method; ``rlm_query.__self__`` is the
-        # parent REPL. Any other scaffold (llm_query, FINAL_VAR, ...)
+        # parent REPL. Any other scaffold (llm_query, SHOW_VARS, ...)
         # would work just as well as a reentry vector.
         result = repl.execute_code("rlm_query.__self__.execute_code('print(\"inner\")')")
     assert (

--- a/tests/test_local_repl.py
+++ b/tests/test_local_repl.py
@@ -124,21 +124,34 @@ class TestLocalREPLContextManager:
 
 
 class TestLocalREPLHelpers:
-    """Tests for helper functions (FINAL_VAR, etc.)."""
+    """Tests for helper functions and the answer-dict completion signal."""
 
-    def test_final_var_existing(self):
-        """Test FINAL_VAR with existing variable."""
+    def test_answer_dict_defaults(self):
+        """The ``answer`` dict starts unready with empty content."""
         repl = LocalREPL()
-        repl.execute_code("answer = 42")
-        _ = repl.execute_code("result = FINAL_VAR('answer')")
-        assert repl.locals["result"] == "42"
+        assert repl.locals["answer"]["content"] == ""
+        assert repl.locals["answer"]["ready"] is False
         repl.cleanup()
 
-    def test_final_var_missing(self):
-        """Test FINAL_VAR with non-existent variable."""
+    def test_answer_ready_surfaces_final_answer(self):
+        """Setting ``answer['ready'] = True`` must surface ``content`` on REPLResult.final_answer."""
         repl = LocalREPL()
-        _ = repl.execute_code("result = FINAL_VAR('nonexistent')")
-        assert "Error" in repl.locals["result"]
+        result = repl.execute_code('answer["content"] = "the result"\nanswer["ready"] = True')
+        assert result.final_answer == "the result"
+        repl.cleanup()
+
+    def test_answer_ready_false_does_not_surface(self):
+        """Mutating ``content`` without flipping ``ready`` must not end the run."""
+        repl = LocalREPL()
+        result = repl.execute_code('answer["content"] = "still working"')
+        assert result.final_answer is None
+        repl.cleanup()
+
+    def test_answer_rebind_to_plain_dict(self):
+        """Rebinding ``answer`` to a plain dict with ready=True is still picked up."""
+        repl = LocalREPL()
+        result = repl.execute_code('answer = {"content": "rebound", "ready": True}')
+        assert result.final_answer == "rebound"
         repl.cleanup()
 
     def test_llm_query_no_handler(self):
@@ -199,14 +212,14 @@ class TestLocalREPLScaffoldRestoration:
         assert "Error" in repl.locals["r"]
         repl.cleanup()
 
-    def test_final_var_restored_after_overwrite(self):
-        """If the model overwrites FINAL_VAR, the next execution still has the real FINAL_VAR."""
+    def test_answer_rewrap_after_rebind(self):
+        """If the model rebinds ``answer`` to a plain dict, the next cell still triggers on ready=True."""
         repl = LocalREPL()
-        repl.execute_code("answer = 42")
-        repl.execute_code("FINAL_VAR = lambda x: 'overwritten'")
-
-        repl.execute_code("result = FINAL_VAR('answer')")
-        assert repl.locals["result"] == "42"
+        repl.execute_code('answer = {"content": "intermediate", "ready": False}')
+        # After scaffold restore, the rebound dict has been wrapped back into the
+        # tracking subclass; setting ready=True now must fire the capture callback.
+        result = repl.execute_code('answer["content"] = "done"; answer["ready"] = True')
+        assert result.final_answer == "done"
         repl.cleanup()
 
 

--- a/tests/test_multi_turn_integration.py
+++ b/tests/test_multi_turn_integration.py
@@ -30,12 +30,17 @@ def create_mock_lm(responses: list[str]) -> Mock:
     return mock
 
 
+def final(content: str) -> str:
+    """Render a model response that submits ``content`` as the final answer."""
+    return f"```repl\nanswer['content'] = {content!r}\nanswer['ready'] = True\n```"
+
+
 class TestMultiTurnPersistentEnvironment:
     """Tests for environment persistence across completion calls."""
 
     def test_environment_reused_in_persistent_mode(self):
         """Verify the same environment instance is reused across completion calls."""
-        responses = ["FINAL(answer from call)"]
+        responses = [final("answer from call")]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
             mock_lm = create_mock_lm(responses)
@@ -59,7 +64,7 @@ class TestMultiTurnPersistentEnvironment:
 
     def test_context_accumulation_across_calls(self):
         """Verify contexts accumulate: context_0, context_1, etc."""
-        responses = ["FINAL(got it)"]
+        responses = [final("got it")]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
             mock_lm = create_mock_lm(responses)
@@ -85,7 +90,7 @@ class TestMultiTurnPersistentEnvironment:
 
     def test_history_accumulation_across_calls(self):
         """Verify message histories accumulate: history_0, history_1, etc."""
-        responses = ["FINAL(done)"]
+        responses = [final("done")]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
             mock_lm = create_mock_lm(responses)
@@ -115,11 +120,11 @@ class TestMultiTurnPersistentEnvironment:
         """Variables computed in one completion should be available in subsequent ones."""
         first_responses = [
             "Let me compute something\n```repl\ncomputed_value = 42 * 2\nprint(computed_value)\n```",
-            "FINAL(84)",
+            final("84"),
         ]
         second_responses = [
             "```repl\nresult = computed_value + 10\nprint(result)\n```",
-            "FINAL(94)",
+            final("94"),
         ]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
@@ -146,7 +151,7 @@ class TestMultiTurnPromptAwareness:
 
     def test_prompt_includes_context_count(self):
         """Model should be informed about available contexts."""
-        responses = ["FINAL(ok)"]
+        responses = [final("ok")]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
             mock_lm = create_mock_lm(responses)
@@ -169,7 +174,7 @@ class TestMultiTurnPromptAwareness:
 
     def test_prompt_includes_history_count(self):
         """Model should be informed about available histories."""
-        responses = ["FINAL(ok)"]
+        responses = [final("ok")]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
             mock_lm = create_mock_lm(responses)
@@ -196,10 +201,10 @@ class TestMultiTurnCodeExecution:
 
     def test_can_access_previous_context_in_code(self):
         """Code should be able to reference earlier contexts."""
-        first_responses = ["FINAL(first done)"]
+        first_responses = [final("first done")]
         second_responses = [
             "```repl\nprint(f'First: {context_0}, Second: {context_1}')\n```",
-            "FINAL(printed both)",
+            final("printed both"),
         ]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
@@ -222,10 +227,10 @@ class TestMultiTurnCodeExecution:
 
     def test_can_access_history_in_code(self):
         """Code should be able to reference stored histories."""
-        first_responses = ["FINAL(first)"]
+        first_responses = [final("first")]
         second_responses = [
             "```repl\nprint(f'History entries: {len(history)}')\n```",
-            "FINAL(accessed history)",
+            final("accessed history"),
         ]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
@@ -252,7 +257,7 @@ class TestNonPersistentMode:
 
     def test_non_persistent_creates_fresh_environment(self):
         """Non-persistent mode should create new environment each call."""
-        responses = ["FINAL(done)"]
+        responses = [final("done")]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
             mock_lm = create_mock_lm(responses)
@@ -285,7 +290,7 @@ class TestPersistentModeResourceManagement:
 
     def test_context_manager_cleanup(self):
         """Environment should be cleaned up when exiting context manager."""
-        responses = ["FINAL(done)"]
+        responses = [final("done")]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
             mock_lm = create_mock_lm(responses)
@@ -303,7 +308,7 @@ class TestPersistentModeResourceManagement:
 
     def test_explicit_close(self):
         """Calling close() should clean up persistent environment."""
-        responses = ["FINAL(done)"]
+        responses = [final("done")]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
             mock_lm = create_mock_lm(responses)
@@ -353,15 +358,15 @@ class TestMultiTurnEndToEnd:
         """Simulate a 3-turn conversation with context accumulation."""
         turn1_responses = [
             "Looking at the first document\n```repl\ndoc1_summary = 'Has info about cats'\nprint(doc1_summary)\n```",
-            "FINAL(Summarized first doc)",
+            final("Summarized first doc"),
         ]
         turn2_responses = [
             "Looking at second document and comparing\n```repl\ndoc2_summary = 'Has info about dogs'\nprint(f'Doc1: {doc1_summary}, Doc2: {doc2_summary}')\n```",
-            "FINAL(Compared both docs)",
+            final("Compared both docs"),
         ]
         turn3_responses = [
             "Final synthesis\n```repl\nfinal = f'Combined: {doc1_summary} and {doc2_summary} from context_2'\nprint(final)\n```",
-            "FINAL(synthesized all)",
+            final("synthesized all"),
         ]
 
         with patch.object(rlm_module, "get_client") as mock_get_client:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,13 +1,10 @@
 """Tests for parsing utilities."""
 
-from unittest.mock import Mock
-
 from rlm.core.types import CodeBlock, REPLResult, RLMIteration
 from rlm.environments.local_repl import LocalREPL
 from rlm.utils.parsing import (
     convert_context_for_repl,
     find_code_blocks,
-    find_final_answer,
     format_execution_result,
     format_iteration,
 )
@@ -78,205 +75,44 @@ print(result)
         assert "return n * factorial(n - 1)" in blocks[0]
 
 
-class TestFindFinalAnswer:
-    """Tests for find_final_answer function."""
+class TestAnswerDictFinalAnswer:
+    """Tests for the ``answer`` dict completion signal surfaced via REPLResult.final_answer."""
 
-    def test_final_answer(self):
-        text = "The answer is:\nFINAL(42)"
-        result = find_final_answer(text)
-        assert result == "42"
-
-    def test_final_var_answer(self):
-        text = "Check the variable:\nFINAL_VAR(result)"
-        # Create a mock environment that returns the variable value
-        mock_env = Mock()
-        mock_env.execute_code.return_value = REPLResult(stdout="42", stderr="", locals={})
-        result = find_final_answer(text, environment=mock_env)
-        assert result == "42"
-        # Verify execute_code was called with the correct code
-        mock_env.execute_code.assert_called_once()
-        call_args = mock_env.execute_code.call_args[0][0]
-        assert "FINAL_VAR('result')" in call_args or 'FINAL_VAR("result")' in call_args
-
-    def test_final_var_without_environment(self):
-        text = "Check the variable:\nFINAL_VAR(result)"
-        # Without environment, FINAL_VAR should return None
-        result = find_final_answer(text)
-        assert result is None
-
-    def test_no_final_answer(self):
-        text = "Still working on the problem..."
-        result = find_final_answer(text)
-        assert result is None
-
-    def test_final_with_multiline_content(self):
-        text = """FINAL(This is a
-multiline answer)"""
-        result = find_final_answer(text)
-        assert result is not None
-        assert "multiline" in result
-        assert "This is a" in result
-
-    def test_final_must_be_at_start_of_line(self):
-        # FINAL not at start of line should not match
-        text = "The result is FINAL(42)"
-        result = find_final_answer(text)
-        assert result is None
-
-    def test_final_with_whitespace(self):
-        text = "   FINAL(answer with spaces)"
-        result = find_final_answer(text)
-        assert result == "answer with spaces"
-
-    def test_final_with_nested_parentheses_greedy_matching(self):
-        """Test that greedy matching captures content with nested parentheses correctly.
-        Greedy matching (.*) matches to the last closing parenthesis, correctly handling
-        nested parentheses in FINAL() content. Non-greedy (.*?) would incorrectly stop
-        at the first closing parenthesis, breaking functions, tuples, and nested structures.
-        """
-        # Function call with nested parentheses
-        text = "FINAL(func(arg1, arg2))"
-        result = find_final_answer(text)
-        assert result == "func(arg1, arg2)"
-
-        # List and tuple with multiple closing parentheses
-        text = "FINAL([1, 2, 3], (4, 5))"
-        result = find_final_answer(text)
-        assert result == "[1, 2, 3], (4, 5)"
-
-        # Complex nested dictionary
-        text = "FINAL({'key': 'value', 'nested': {'a': 1, 'b': 2}})"
-        result = find_final_answer(text)
-        assert "'key': 'value'" in result
-        assert "'nested':" in result
-
-        # Multiple function calls with nested parentheses
-        text = "FINAL(calculate(10, 20) + process(data))"
-        result = find_final_answer(text)
-        assert result == "calculate(10, 20) + process(data)"
-
-    def test_final_and_final_var_parsing(self):
-        """Test that both FINAL and FINAL_VAR patterns are parsed correctly."""
-        # Test FINAL with various content types
-        test_cases_final = [
-            ("FINAL(42)", "42"),
-            ("FINAL('hello world')", "'hello world'"),
-            ('FINAL("test")', '"test"'),
-            ("FINAL(123.45)", "123.45"),
-            ("FINAL([1, 2, 3])", "[1, 2, 3]"),
-        ]
-
-        for text, expected in test_cases_final:
-            result = find_final_answer(text)
-            assert result == expected, f"Failed for text: {text}"
-
-        # Test FINAL_VAR with environment
-        mock_env = Mock()
-        mock_env.execute_code.return_value = REPLResult(
-            stdout="computed_result", stderr="", locals={}
-        )
-
-        test_cases_final_var = [
-            ("FINAL_VAR(result)", "result"),
-            ("FINAL_VAR('my_var')", "my_var"),
-            ('FINAL_VAR("another_var")', "another_var"),
-            ("FINAL_VAR(answer)", "answer"),
-        ]
-
-        for text, var_name in test_cases_final_var:
-            result = find_final_answer(text, environment=mock_env)
-            assert result == "computed_result", f"Failed for text: {text}"
-            # Verify the variable name was extracted correctly
-            call_args = mock_env.execute_code.call_args[0][0]
-            assert (
-                var_name in call_args
-                or f"'{var_name}'" in call_args
-                or f'"{var_name}"' in call_args
-            )
-
-    def test_final_var_takes_precedence_over_final(self):
-        """Test that FINAL_VAR is checked first and takes precedence over FINAL."""
-        mock_env = Mock()
-        mock_env.execute_code.return_value = REPLResult(stdout="var_value", stderr="", locals={})
-
-        # If both appear, FINAL_VAR should be found first (checked first in the function)
-        text = "FINAL_VAR(result)\nFINAL(direct_answer)"
-        result = find_final_answer(text, environment=mock_env)
-        assert result == "var_value"  # FINAL_VAR should be returned
-
-        # Without environment, FINAL_VAR pattern is found but returns None (no fallback to FINAL)
-        # This is expected behavior - FINAL_VAR takes precedence when found
-        result = find_final_answer(text)
-        assert result is None  # FINAL_VAR found but no environment, so returns None
-
-        # Test that FINAL alone works when FINAL_VAR is not present
-        text_final_only = "FINAL(direct_answer)"
-        result = find_final_answer(text_final_only)
-        assert result == "direct_answer"
-
-    def test_final_var_retrieves_actual_variables_from_environment(self):
-        """Test that FINAL_VAR actually retrieves variables from a real code environment."""
-        # Create a real LocalREPL environment
+    def test_answer_dict_ready_true_sets_final_answer(self):
+        """Setting ``answer['ready'] = True`` must populate REPLResult.final_answer."""
         env = LocalREPL()
-
         try:
-            # Execute code to create variables with different types
-            env.execute_code("x = 42")
-            env.execute_code("result = 'hello world'")
-            env.execute_code("answer = [1, 2, 3, 4, 5]")
-            env.execute_code("computed = 10 * 5 + 2")
-            env.execute_code("nested = {'key': 'value', 'num': 123}")
-
-            # Test retrieving integer variable
-            text = "FINAL_VAR(x)"
-            result = find_final_answer(text, environment=env)
-            assert result == "42", f"Expected '42', got '{result}'"
-
-            # Test retrieving string variable
-            text = "FINAL_VAR(result)"
-            result = find_final_answer(text, environment=env)
-            assert result == "hello world", f"Expected 'hello world', got '{result}'"
-
-            # Test retrieving list variable
-            text = "FINAL_VAR(answer)"
-            result = find_final_answer(text, environment=env)
-            assert result == "[1, 2, 3, 4, 5]", f"Expected '[1, 2, 3, 4, 5]', got '{result}'"
-
-            # Test retrieving computed variable
-            text = "FINAL_VAR(computed)"
-            result = find_final_answer(text, environment=env)
-            assert result == "52", f"Expected '52', got '{result}'"
-
-            # Test retrieving dictionary variable
-            text = "FINAL_VAR(nested)"
-            result = find_final_answer(text, environment=env)
-            assert "'key': 'value'" in result or '"key": "value"' in result
-            assert "'num': 123" in result or '"num": 123' in result
-
-            # Test that variable updates are reflected
-            env.execute_code("x = 100")
-            text = "FINAL_VAR(x)"
-            result = find_final_answer(text, environment=env)
-            assert result == "100", f"Expected '100', got '{result}'"
-
-            # Non-existent variable: find_final_answer must return None (not the error string)
-            # so the RLM loop continues and the model can fix it
-            text = "FINAL_VAR(nonexistent)"
-            result = find_final_answer(text, environment=env)
-            assert result is None, "must return None for variable-not-found, not the error message"
+            result = env.execute_code('answer["content"] = "the result"\nanswer["ready"] = True')
+            assert result.final_answer == "the result"
         finally:
             env.cleanup()
 
-    def test_final_var_variable_not_found_returns_none(self):
-        """When env returns FINAL_VAR 'variable not found' error, find_final_answer must return None."""
-        mock_env = Mock()
-        mock_env.execute_code.return_value = REPLResult(
-            stdout="Error: Variable 'missing' not found. Available variables: []. You must create and assign a variable BEFORE calling FINAL_VAR on it.",
-            stderr="",
-            locals={},
-        )
-        result = find_final_answer("FINAL_VAR(missing)", environment=mock_env)
-        assert result is None
+    def test_answer_dict_unset_keeps_final_answer_none(self):
+        """If ``ready`` stays False, the REPL must not surface a final answer."""
+        env = LocalREPL()
+        try:
+            result = env.execute_code('answer["content"] = "wip"')
+            assert result.final_answer is None
+        finally:
+            env.cleanup()
+
+    def test_answer_dict_rebind_with_ready(self):
+        """Plain-dict rebind with ``ready=True`` must still be captured."""
+        env = LocalREPL()
+        try:
+            result = env.execute_code('answer = {"content": "rebound", "ready": True}')
+            assert result.final_answer == "rebound"
+        finally:
+            env.cleanup()
+
+    def test_answer_content_can_be_non_string(self):
+        """Any ``str()``-able content (numbers, lists) should be coerced to a string final answer."""
+        env = LocalREPL()
+        try:
+            result = env.execute_code('answer["content"] = [1, 2, 3]\nanswer["ready"] = True')
+            assert result.final_answer == "[1, 2, 3]"
+        finally:
+            env.cleanup()
 
 
 class TestFormatExecutionResult:

--- a/tests/test_subcall.py
+++ b/tests/test_subcall.py
@@ -31,6 +31,11 @@ def create_mock_lm(responses: list[str], model_name: str = "mock-model") -> Mock
     return mock
 
 
+def final(content: str) -> str:
+    """Render a model response that submits ``content`` as the final answer."""
+    return f"```repl\nanswer['content'] = {content!r}\nanswer['ready'] = True\n```"
+
+
 class TestSubcallTimeoutPropagation:
     """Tests for max_timeout propagation to child RLM."""
 
@@ -48,7 +53,7 @@ class TestSubcallTimeoutPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             # Create parent RLM with max_timeout
@@ -87,7 +92,7 @@ class TestSubcallTimeoutPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -107,7 +112,7 @@ class TestSubcallTimeoutPropagation:
     def test_subcall_returns_error_when_timeout_exhausted(self):
         """When timeout is already exhausted, _subcall should return error message."""
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -142,7 +147,7 @@ class TestSubcallTokensPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -171,7 +176,7 @@ class TestSubcallTokensPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -204,7 +209,7 @@ class TestSubcallErrorsPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -233,7 +238,7 @@ class TestSubcallErrorsPropagation:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -266,7 +271,7 @@ class TestSubcallModelOverride:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -299,7 +304,7 @@ class TestSubcallModelOverride:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -330,7 +335,7 @@ class TestSubcallModelOverride:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(
@@ -396,7 +401,7 @@ class TestSubcallModelOverrideAtLeafDepth:
     def test_leaf_depth_without_model_override_uses_parent_model(self):
         """When at max_depth without model override, uses parent's model."""
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"] * 2 + ["leaf response"])
+            mock_lm = create_mock_lm([final("answer")] * 2 + ["leaf response"])
             mock_get_client.return_value = mock_lm
 
             # Parent at depth 1, max_depth 2 means next depth (2) will be at max_depth
@@ -438,7 +443,7 @@ class TestSubcallCombinedParameters:
                 super().__init__(*args, **kwargs)
 
         with patch.object(rlm_module, "get_client") as mock_get_client:
-            mock_lm = create_mock_lm(["FINAL(answer)"])
+            mock_lm = create_mock_lm([final("answer")])
             mock_get_client.return_value = mock_lm
 
             parent = RLM(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -135,11 +135,11 @@ class TestRLMIteration:
     def test_with_final_answer(self):
         iteration = RLMIteration(
             prompt="test",
-            response="FINAL(42)",
+            response="42",
             code_blocks=[],
-            final_answer=("FINAL", "42"),
+            final_answer="42",
         )
-        assert iteration.final_answer == ("FINAL", "42")
+        assert iteration.final_answer == "42"
 
     def test_to_dict(self):
         result = REPLResult(stdout="", stderr="", locals={})


### PR DESCRIPTION
Change the `FINAL(...) / FINAL_VAR(...)` answer format to be more principled.

Following DSPy.RLM & `verifiers` RLMEnv, we use the REPL as a place to store the final answer. We use a `answer` dictionary that is pre-populated / protected with 2 keys, "content" and "ready".

"content" is where answers are placed, and "ready" is set to True when the answer is ready to be submitted.