### PR TITLE
fix(core): instantiate each sub-client exactly once in _spawn_completion_context

### DIFF
--- a/rlm/core/rlm.py
+++ b/rlm/core/rlm.py
@@ -206,9 +206,16 @@ class RLM:
 
         lm_handler = LMHandler(client, other_backend_client=other_backend_client)
 
-        # Register other clients to be available as sub-call options (by model name)
-        if self.other_backends and self.other_backend_kwargs:
-            for backend, kwargs in zip(self.other_backends, self.other_backend_kwargs, strict=True):
+        # Register other clients to be available as sub-call options (by model name).
+        # Reuse other_backend_client for the first entry so each (backend, kwargs)
+        # pair is instantiated exactly once.
+        if other_backend_client is not None:
+            lm_handler.register_client(other_backend_client.model_name, other_backend_client)
+            for backend, kwargs in zip(
+                self.other_backends[1:],
+                self.other_backend_kwargs[1:],
+                strict=True,
+            ):
                 other_client: BaseLM = get_client(backend, kwargs)
                 lm_handler.register_client(other_client.model_name, other_client)
 


### PR DESCRIPTION
## Summary
- Replaces #159 with a rebased, single-commit version of the same fix.
- In `_spawn_completion_context`, the first sub-client was constructed twice — once for `other_backend_client` and again inside the registration loop. Reuse `other_backend_client` for the first registration and only construct the remaining sub-clients in the loop.

## Why it matters
- Backends with expensive underlying state (HTTP connection pools, async clients, OS sockets) paid the cost twice. With multi-backend Anthropic on macOS this surfaced as a ~3-min hang at iter 2 of every multi-backend trajectory.
- Usage tracking merges via `dict.update` in `lm_handler.py`, so the duplicate instance overwrote one of the two clients' usage summaries.