### PR TITLE
Add docker changes to support persistence + parallel sub-calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ The default `local` environment `LocalREPL` runs in the same process as the RLM 
 `IPythonREPL` runs cells inside a real IPython session — either in-process (default) or in a separate `ipykernel` subprocess. Subprocess mode adds hard `cell_timeout` enforcement and full namespace isolation from the RLM host. See the [IPythonREPL docs](https://alexzhang13.github.io/rlm/environments/ipython) for details.
 
 #### Docker <img src="https://github.com/docker.png" alt="Docker" height="20" style="vertical-align: middle;"/> (*requires [Docker installed](https://docs.docker.com/desktop/setup/install/)*)
-We also support a Docker-based environment called `DockerREPL` that launches the REPL environment as a Docker image. By default, we use the `python:3.11-slim` image, but the user can specify custom images as well.
+We also support a Docker-based environment called `DockerREPL` that launches the REPL environment as a Docker image. By default, we use the `python:3.11-slim` image, but the user can specify custom images as well. The container runs fully isolated from the host; a lightweight host-side proxy bridges LM access back into the container.
+
+`DockerREPL` supports the full feature set of the local environment: single LM calls (`llm_query` / `llm_query_batched`), recursive sub-RLM calls (`rlm_query` / `rlm_query_batched`, including parallel batched sub-calls bounded by `max_concurrent_subcalls`), `custom_tools` / `custom_sub_tools`, `persistent=True` multi-turn sessions (versioned `context_N` / `history_N` reused across `completion()` calls), and `compaction=True` auto-summarization of the running `history`. For isolated environments, custom tools should be passed as Python code strings or JSON-serializable values (host callables cannot cross the process boundary).
 
 ### Isolated Environments
 We support several different REPL environments that run on separate, cloud-based machines. Whenever a recursive sub-call is made in these instances, it is requested from the host process.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -214,7 +214,9 @@ rlm = RLM(
 
 ### Docker
 
-Code runs in a Docker container with full isolation.
+Code runs in a Docker container with full isolation. A lightweight host-side
+proxy bridges LM access back into the container, so the container never needs
+API keys or direct network access to the model provider.
 
 ```python
 rlm = RLM(
@@ -227,7 +229,19 @@ rlm = RLM(
 )
 ```
 
-**Pros:** Containerized isolation, reproducible  
+`DockerREPL` supports the same capabilities as the local environment:
+
+- `llm_query` / `llm_query_batched` — single LM completions
+- `rlm_query` / `rlm_query_batched` — recursive sub-RLM calls (with `max_depth > 1`),
+  including parallel batched sub-calls bounded by `max_concurrent_subcalls`
+- `custom_tools` / `custom_sub_tools` — injected functions/data (pass as Python
+  code strings or JSON-serializable values, since host callables cannot cross
+  the container boundary)
+- `persistent=True` — multi-turn sessions; the container and its namespace are
+  kept alive across `completion()` calls, with versioned `context_N` / `history_N`
+- `compaction=True` — auto-summarizes the running `history` when context fills up
+
+**Pros:** Containerized isolation, reproducible, full feature parity with local  
 **Cons:** Requires Docker, slower startup
 
 ### Modal

--- a/examples/docker_repl_example.py
+++ b/examples/docker_repl_example.py
@@ -1,16 +1,24 @@
 """
-Docker REPL example with code execution and LLM queries.
+Docker REPL example with code execution, LLM queries, recursive sub-RLM calls,
+and custom tools.
 
 Setup:
     1. Ensure Docker is running
     2. Run: python -m examples.docker_repl_example
 
 The default image (python:3.11-slim) will be pulled automatically.
+
+Persistence and compaction:
+    DockerREPL also supports multi-turn persistence and compaction. Drive them
+    through the RLM rather than the env directly, e.g.:
+
+        rlm = RLM(backend=..., environment="docker", persistent=True)   # multi-turn
+        rlm = RLM(backend=..., environment="docker", compaction=True)   # auto-summarize
 """
 
 from rlm.clients.base_lm import BaseLM
 from rlm.core.lm_handler import LMHandler
-from rlm.core.types import ModelUsageSummary, UsageSummary
+from rlm.core.types import ModelUsageSummary, RLMChatCompletion, UsageSummary
 from rlm.environments.docker_repl import DockerREPL
 
 
@@ -60,6 +68,32 @@ def main():
             result = repl.execute_code('rs = llm_query_batched(["Q1", "Q2"])')
             result = repl.execute_code("print(len(rs))")
             print(f"  Batched count: {result.stdout.strip()}")
+
+    # Recursive sub-RLM calls + custom tools
+    print("\n[3] Recursive sub-RLM (rlm_query) + custom tools")
+
+    def mock_subcall(prompt, model=None):
+        # In real use this is RLM._subcall, which spawns a child RLM.
+        return RLMChatCompletion(
+            root_model=model or "child",
+            prompt=prompt,
+            response=f"child-answer({prompt})",
+            usage_summary=UsageSummary(model_usage_summaries={}),
+            execution_time=0.0,
+        )
+
+    with DockerREPL(
+        subcall_fn=mock_subcall,
+        custom_tools={"triple": "def triple(x):\n    return x * 3", "CONST": 7},
+    ) as repl:
+        result = repl.execute_code("print(triple(CONST))")
+        print(f"  custom tools triple(CONST) → {result.stdout.strip()}")
+
+        result = repl.execute_code('print(rlm_query("solve subtask"))')
+        print(f"  rlm_query → {result.stdout.strip()}")
+
+        result = repl.execute_code('print(rlm_query_batched(["a", "b", "c"]))')
+        print(f"  rlm_query_batched → {result.stdout.strip()}")
 
     print("\n" + "=" * 50)
     print("Done!")

--- a/rlm/core/rlm.py
+++ b/rlm/core/rlm.py
@@ -272,15 +272,17 @@ class RLM:
             env_kwargs["lm_handler_address"] = (lm_handler.host, lm_handler.port)
             env_kwargs["context_payload"] = prompt
             env_kwargs["depth"] = self.depth + 1  # Environment depth is RLM depth + 1
-            # For local/ipython environments with max_depth > 1, pass subcall callback for recursive RLM calls
-            if self.environment_type in ("local", "ipython") and self.max_depth > 1:
+            # For environments that support recursive RLM calls, pass the subcall
+            # callback when max_depth > 1. local/ipython invoke it in-process;
+            # docker invokes it via its host-side proxy (/rlm_query endpoints).
+            if self.environment_type in ("local", "ipython", "docker") and self.max_depth > 1:
                 env_kwargs["subcall_fn"] = self._subcall
             # Pass custom tools to the environment
             if self.custom_tools is not None:
                 env_kwargs["custom_tools"] = self.custom_tools
             if self.custom_sub_tools is not None:
                 env_kwargs["custom_sub_tools"] = self.custom_sub_tools
-            if self.compaction and self.environment_type == "local":
+            if self.compaction and self.environment_type in ("local", "docker"):
                 env_kwargs["compaction"] = True
             env_kwargs["max_concurrent_subcalls"] = self.max_concurrent_subcalls
             environment: BaseEnv = get_environment(self.environment_type, env_kwargs)
@@ -876,13 +878,13 @@ class RLM:
         - add_context(payload, index): Add new context for multi-turn conversations
         - get_context_count(): Return the number of loaded contexts
 
-        Currently only 'local' (LocalREPL) supports these methods.
+        Currently 'local', 'ipython', and 'docker' support these methods.
 
         Raises:
             ValueError: If the environment type does not support persistent mode.
         """
         # Known environments that support persistence
-        persistent_supported_environments = {"local", "ipython"}
+        persistent_supported_environments = {"local", "ipython", "docker"}
 
         if self.environment_type not in persistent_supported_environments:
             raise ValueError(

--- a/rlm/environments/docker_repl.py
+++ b/rlm/environments/docker_repl.py
@@ -1,6 +1,16 @@
 """
 Docker REPL environment that runs Python code in a Docker container.
 
+The container is fully isolated from the host LM process. An HTTP proxy on the
+host bridges the gap so code running in the container can:
+
+    - llm_query / llm_query_batched : single LM completions (no recursion)
+    - rlm_query  / rlm_query_batched : recursive RLM sub-calls (spawns a child
+                                       RLM on the host when max_depth > 1)
+    - SHOW_VARS                      : list REPL variables
+    - custom tools                  : user-supplied functions/data
+    - answer                        : answer["ready"] = True signals completion
+
 Setup:
     docker build -t rlm-sandbox -f Dockerfile.sandbox .
 
@@ -8,56 +18,109 @@ Or use any Python 3.11+ image with: pip install dill requests
 """
 
 import base64
+import copy
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import textwrap
 import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
 
 from rlm.core.comms_utils import LMRequest, send_lm_request, send_lm_request_batched
 from rlm.core.types import REPLResult, RLMChatCompletion
-from rlm.environments.base_env import NonIsolatedEnv
+from rlm.environments.base_env import (
+    NonIsolatedEnv,
+    extract_tool_value,
+    validate_custom_tools,
+)
 
 
 class LLMProxyHandler(BaseHTTPRequestHandler):
-    """HTTP handler for LLM requests from the container."""
+    """HTTP handler for LLM/RLM requests from the container.
+
+    Class attributes are overridden per-environment via a dynamically created
+    subclass (see DockerREPL.setup). Each DockerREPL gets its own handler class
+    bound to its own ``pending_calls`` list, lock, depth, and subcall callback.
+    """
 
     lm_handler_address: tuple[str, int] | None = None
     pending_calls: list[RLMChatCompletion] = []
     lock: threading.Lock = threading.Lock()
     depth: int = 1
+    # Callback for recursive RLM sub-calls. ``None`` means recursion is not
+    # configured, so rlm_query falls back to a plain llm_query.
+    subcall_fn: Callable[[str, str | None], RLMChatCompletion] | None = None
+    max_concurrent_subcalls: int = 4
 
     def log_message(self, *args):
         pass
 
-    def do_POST(self):
-        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+    def _resolve_address(self) -> tuple[str, int] | None:
+        """Read the LM handler address dynamically.
 
-        if self.path == "/llm_query":
-            result = self._handle_single(body)
-        elif self.path == "/llm_query_batched":
-            result = self._handle_batched(body)
-        else:
-            self._respond(404, {"error": "Not found"})
+        In persistent (multi-turn) mode each completion() spawns a new LMHandler
+        on a new port, so the live address is stored on the server instance and
+        updated via DockerREPL.update_handler_address. Fall back to the class
+        attribute for the non-persistent case.
+        """
+        return getattr(self.server, "lm_handler_address", None) or self.lm_handler_address
+
+    def do_POST(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length)) if length else {}
+        except Exception as e:
+            self._respond(400, {"error": f"Bad request: {e}"})
+            return
+
+        try:
+            if self.path == "/llm_query":
+                result = self._handle_single(body)
+            elif self.path == "/llm_query_batched":
+                result = self._handle_batched(body)
+            elif self.path == "/rlm_query":
+                result = self._handle_rlm_single(body)
+            elif self.path == "/rlm_query_batched":
+                result = self._handle_rlm_batched(body)
+            else:
+                self._respond(404, {"error": "Not found"})
+                return
+        except Exception as e:
+            # Never let a handler crash leave the container waiting on a dropped
+            # connection; always return a structured error it can surface.
+            self._respond(500, {"error": f"Proxy handler error: {e}"})
             return
 
         self._respond(200, result)
 
     def _respond(self, status: int, data: dict):
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.end_headers()
-        self.wfile.write(json.dumps(data).encode())
+        try:
+            payload = json.dumps(data).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        except (BrokenPipeError, ConnectionError, OSError):
+            # Container-side request closed early (e.g. timeout). Nothing to do.
+            pass
 
+    # ------------------------------------------------------------------ #
+    # Single-completion LM calls (no recursion)
+    # ------------------------------------------------------------------ #
     def _handle_single(self, body: dict) -> dict:
-        if not self.lm_handler_address:
+        address = self._resolve_address()
+        if not address:
             return {"error": "No LM handler configured"}
 
         request = LMRequest(prompt=body.get("prompt"), model=body.get("model"), depth=self.depth)
-        response = send_lm_request(self.lm_handler_address, request)
+        response = send_lm_request(address, request)
 
         if not response.success:
             return {"error": response.error}
@@ -68,12 +131,13 @@ class LLMProxyHandler(BaseHTTPRequestHandler):
         return {"response": response.chat_completion.response}
 
     def _handle_batched(self, body: dict) -> dict:
-        if not self.lm_handler_address:
+        address = self._resolve_address()
+        if not address:
             return {"error": "No LM handler configured"}
 
         prompts = body.get("prompts", [])
         responses = send_lm_request_batched(
-            self.lm_handler_address, prompts, model=body.get("model"), depth=self.depth
+            address, prompts, model=body.get("model"), depth=self.depth
         )
 
         results = []
@@ -87,10 +151,127 @@ class LLMProxyHandler(BaseHTTPRequestHandler):
 
         return {"responses": results}
 
+    # ------------------------------------------------------------------ #
+    # Recursive RLM sub-calls (spawns child RLMs on the host)
+    # ------------------------------------------------------------------ #
+    def _handle_rlm_single(self, body: dict) -> dict:
+        # No recursive capability configured -> behave like a plain llm_query.
+        if self.subcall_fn is None:
+            return self._handle_single(body)
 
-def _build_exec_script(code: str, proxy_port: int, depth: int = 1) -> str:
-    """Build execution script for the container."""
+        prompt = body.get("prompt")
+        model = body.get("model")
+        try:
+            completion = self.subcall_fn(prompt, model)
+        except Exception as e:
+            return {"error": f"RLM query failed - {e}"}
+
+        # Read .response before tracking so a malformed completion isn't recorded.
+        result = {"response": completion.response}
+        with self.lock:
+            self.pending_calls.append(completion)
+        return result
+
+    def _handle_rlm_batched(self, body: dict) -> dict:
+        if self.subcall_fn is None:
+            return self._handle_batched(body)
+
+        prompts = body.get("prompts", [])
+        model = body.get("model")
+        n = len(prompts)
+        if n == 0:
+            return {"responses": []}
+
+        # Pre-allocate to preserve input order regardless of completion order.
+        results: list[str] = [""] * n
+        completions: list[tuple[int, RLMChatCompletion]] = []
+        comp_lock = threading.Lock()
+
+        def _run(index: int, prompt: str) -> None:
+            try:
+                completion = self.subcall_fn(prompt, model)
+                with comp_lock:
+                    completions.append((index, completion))
+                results[index] = completion.response
+            except Exception as e:
+                results[index] = f"Error: RLM query failed - {e}"
+
+        if n == 1:
+            _run(0, prompts[0])
+        else:
+            max_workers = min(self.max_concurrent_subcalls, n)
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [executor.submit(_run, i, p) for i, p in enumerate(prompts)]
+                for future in as_completed(futures):
+                    future.result()
+
+        # Record completions in prompt order for deterministic metadata.
+        completions.sort(key=lambda x: x[0])
+        with self.lock:
+            for _, completion in completions:
+                self.pending_calls.append(completion)
+
+        return {"responses": results}
+
+
+def _build_custom_tools_code(custom_tools: dict[str, Any] | None) -> str:
+    """Build the in-container injection code for custom tools.
+
+    Mirrors DaytonaREPL semantics for out-of-process environments:
+        - String values that look like code (def/class/lambda/multiline) are
+          executed directly to define a function/class.
+        - Everything else is JSON-serialized and loaded as data.
+    Arbitrary host callables cannot cross the process boundary and are skipped.
+    """
+    if not custom_tools:
+        return ""
+
+    lines: list[str] = []
+    for name, entry in custom_tools.items():
+        value = extract_tool_value(entry)
+
+        if isinstance(value, str) and (
+            value.strip().startswith("def ")
+            or value.strip().startswith("class ")
+            or value.strip().startswith("lambda")
+            or "\n" in value
+        ):
+            lines.append(f"# Custom tool: {name}")
+            lines.append(value)
+            lines.append(f"_globals['{name}'] = {name}")
+        elif callable(value):
+            # Host callable - cannot be serialized into the container.
+            lines.append(
+                f"# Warning: custom tool '{name}' is a host callable and is not "
+                f"available in the docker environment. Pass it as a code string instead."
+            )
+        else:
+            try:
+                json_value = json.dumps(value)
+                lines.append(f"_locals['{name}'] = json.loads({json_value!r})")
+            except (TypeError, ValueError):
+                lines.append(f"# Warning: Could not serialize tool '{name}'")
+
+    return "\n".join(lines)
+
+
+def _build_exec_script(
+    code: str,
+    proxy_port: int,
+    depth: int = 1,
+    custom_tools: dict[str, Any] | None = None,
+    compaction: bool = False,
+) -> str:
+    """Build the per-cell execution script that runs inside the container."""
     code_b64 = base64.b64encode(code.encode()).decode()
+    custom_tools_code = _build_custom_tools_code(custom_tools)
+    # In compaction mode the running summary list owns `history`; don't let the
+    # versioned history_0 alias clobber it (the host re-injects it each turn).
+    history_alias = (
+        ""
+        if compaction
+        else 'if "history_0" in _locals:\n    _locals["history"] = _locals["history_0"]'
+    )
 
     return textwrap.dedent(
         f'''
@@ -102,19 +283,40 @@ except ImportError:
 
 PROXY = "http://host.docker.internal:{proxy_port}"
 STATE = "/workspace/state.dill"
+DEPTH = {depth}
+
+# Generous timeouts: plain LM calls can be slow; recursive RLM calls slower still.
+_LLM_TIMEOUT = 600
+_RLM_TIMEOUT = 3600
+
+def _post(path, payload, timeout):
+    r = requests.post(f"{{PROXY}}{{path}}", json=payload, timeout=timeout)
+    return r.json()
 
 def llm_query(prompt, model=None):
     try:
-        r = requests.post(f"{{PROXY}}/llm_query", json={{"prompt": prompt, "model": model, "depth": {depth}}}, timeout=300)
-        d = r.json()
+        d = _post("/llm_query", {{"prompt": prompt, "model": model, "depth": DEPTH}}, _LLM_TIMEOUT)
         return d.get("response") or f"Error: {{d.get('error')}}"
     except Exception as e:
         return f"Error: {{e}}"
 
 def llm_query_batched(prompts, model=None):
     try:
-        r = requests.post(f"{{PROXY}}/llm_query_batched", json={{"prompts": prompts, "model": model, "depth": {depth}}}, timeout=300)
-        d = r.json()
+        d = _post("/llm_query_batched", {{"prompts": prompts, "model": model, "depth": DEPTH}}, _LLM_TIMEOUT)
+        return d.get("responses") or [f"Error: {{d.get('error')}}"] * len(prompts)
+    except Exception as e:
+        return [f"Error: {{e}}"] * len(prompts)
+
+def rlm_query(prompt, model=None):
+    try:
+        d = _post("/rlm_query", {{"prompt": prompt, "model": model, "depth": DEPTH}}, _RLM_TIMEOUT)
+        return d.get("response") or f"Error: {{d.get('error')}}"
+    except Exception as e:
+        return f"Error: {{e}}"
+
+def rlm_query_batched(prompts, model=None):
+    try:
+        d = _post("/rlm_query_batched", {{"prompts": prompts, "model": model, "depth": DEPTH}}, _RLM_TIMEOUT)
         return d.get("responses") or [f"Error: {{d.get('error')}}"] * len(prompts)
     except Exception as e:
         return [f"Error: {{e}}"] * len(prompts)
@@ -124,17 +326,20 @@ def load_state():
         try:
             with open(STATE, "rb") as f:
                 return dill.load(f)
-        except:
+        except Exception:
             pass
     return {{}}
 
 def save_state(s):
-    clean = {{k: v for k, v in s.items() if not k.startswith("_")}}
-    for k in list(clean.keys()):
+    clean = {{}}
+    for k, v in s.items():
+        if k.startswith("_"):
+            continue
         try:
-            dill.dumps(clean[k])
-        except:
-            del clean[k]
+            dill.dumps(v)
+            clean[k] = v
+        except Exception:
+            pass
     with open(STATE, "wb") as f:
         dill.dump(clean, f)
 
@@ -150,7 +355,19 @@ def SHOW_VARS():
         return "No variables created yet. Use ```repl``` blocks to create variables."
     return f"Available variables: {{available}}"
 
-_globals = {{"__builtins__": __builtins__, "__name__": "__main__", "llm_query": llm_query, "llm_query_batched": llm_query_batched, "SHOW_VARS": SHOW_VARS}}
+_globals = {{
+    "__builtins__": __builtins__,
+    "__name__": "__main__",
+    "llm_query": llm_query,
+    "llm_query_batched": llm_query_batched,
+    "rlm_query": rlm_query,
+    "rlm_query_batched": rlm_query_batched,
+    "SHOW_VARS": SHOW_VARS,
+}}
+
+# --- Custom tools injection ---
+{custom_tools_code}
+# --- End custom tools ---
 
 code = base64.b64decode("{code_b64}").decode()
 stdout_buf, stderr_buf = io.StringIO(), io.StringIO()
@@ -163,7 +380,7 @@ try:
     for k, v in combined.items():
         if k not in _globals and not k.startswith("_"):
             _locals[k] = v
-except:
+except Exception:
     traceback.print_exc(file=stderr_buf)
 finally:
     sys.stdout, sys.stderr = old_stdout, old_stderr
@@ -171,24 +388,38 @@ finally:
 # Restore scaffold aliases if overwritten by executed code
 if "context_0" in _locals:
     _locals["context"] = _locals["context_0"]
-if "history_0" in _locals:
-    _locals["history"] = _locals["history_0"]
+{history_alias}
 
 save_state(_locals)
 _ans = _locals.get("answer") if isinstance(_locals.get("answer"), dict) else None
 _final = None
 if _ans is not None and _ans.get("ready"):
     _final = str(_ans.get("content", ""))
-print(json.dumps({{"stdout": stdout_buf.getvalue(), "stderr": stderr_buf.getvalue(), "locals": {{k: repr(v) for k, v in _locals.items() if not k.startswith("_")}}, "final_answer": _final}}, ensure_ascii=False))
+print(json.dumps({{
+    "stdout": stdout_buf.getvalue(),
+    "stderr": stderr_buf.getvalue(),
+    "locals": {{k: repr(v) for k, v in _locals.items() if not k.startswith("_")}},
+    "final_answer": _final,
+}}, ensure_ascii=False))
 '''
     )
 
 
 class DockerREPL(NonIsolatedEnv):
     """
-    Docker REPL - runs Python in a Docker container with LLM support.
+    Docker REPL - runs Python in a Docker container with LLM and recursive RLM support.
 
     Requires: Docker with a Python 3.11+ image (default: python:3.11-slim).
+
+    Supports:
+        - llm_query / llm_query_batched : single LM completions
+        - rlm_query  / rlm_query_batched : recursive RLM sub-calls (needs subcall_fn)
+        - custom_tools / custom_sub_tools : injected functions/data
+        - answer["ready"] = True : final-answer signaling
+        - persistent multi-turn sessions : versioned context_N / history_N reuse
+          across completion() calls (the container and its dill state are kept
+          alive for the lifetime of the env)
+        - compaction : auto-summarized running `history` when context fills up
     """
 
     def __init__(
@@ -199,20 +430,45 @@ class DockerREPL(NonIsolatedEnv):
         setup_code: str | None = None,
         persistent: bool = False,
         depth: int = 1,
+        subcall_fn: Callable[[str, str | None], RLMChatCompletion] | None = None,
+        custom_tools: dict[str, Any] | None = None,
+        custom_sub_tools: dict[str, Any] | None = None,
+        compaction: bool = False,
+        max_concurrent_subcalls: int = 4,
         **kwargs,
     ):
-        if persistent:
-            raise NotImplementedError(
-                "Persistent REPLs are currently not supported for environment: DockerREPL"
-            )
-        super().__init__(persistent=persistent, depth=depth, **kwargs)
+        super().__init__(
+            persistent=persistent,
+            depth=depth,
+            max_concurrent_subcalls=max_concurrent_subcalls,
+            **kwargs,
+        )
 
         self.image = image
         self.lm_handler_address = lm_handler_address
+        self.subcall_fn = subcall_fn
+        self.compaction = compaction
         self.container_id: str | None = None
-        self.proxy_server: HTTPServer | None = None
+        self.proxy_server: ThreadingHTTPServer | None = None
         self.proxy_thread: threading.Thread | None = None
         self.proxy_port: int = 0
+        self._cleaned_up = False
+
+        # Multi-turn persistence bookkeeping (context_N / history_N versioning).
+        self._context_count: int = 0
+        self._history_count: int = 0
+        # Compaction keeps the canonical running history host-side and re-injects
+        # it into the container as `history` on each update (see local_repl.py).
+        self._compaction_history: list[Any] = []
+
+        # Custom tools: functions/data available in the REPL.
+        self.custom_tools = custom_tools or {}
+        # Sub-tools inherit from custom_tools unless explicitly provided.
+        self.custom_sub_tools = (
+            custom_sub_tools if custom_sub_tools is not None else self.custom_tools
+        )
+        validate_custom_tools(self.custom_tools)
+
         base_dir = os.environ.get(
             "RLM_DOCKER_WORKSPACE_DIR", os.path.join(os.getcwd(), ".rlm_workspace")
         )
@@ -223,14 +479,20 @@ class DockerREPL(NonIsolatedEnv):
 
         self.setup()
 
-        if context_payload:
+        # In compaction mode the model reads the accumulated trajectory via the
+        # `history` REPL variable; seed it as an empty list up front.
+        if self.compaction:
+            self._inject_history(self._compaction_history)
+
+        if context_payload is not None:
             self.load_context(context_payload)
         if setup_code:
             self.execute_code(setup_code)
 
     def setup(self):
         """Start the proxy server and Docker container."""
-        # Start LLM proxy server
+        # Start LLM/RLM proxy server (multi-threaded so concurrent sub-calls
+        # don't serialize or deadlock behind a single in-flight handler).
         handler = type(
             "Handler",
             (LLMProxyHandler,),
@@ -239,9 +501,15 @@ class DockerREPL(NonIsolatedEnv):
                 "pending_calls": self.pending_calls,
                 "lock": self._calls_lock,
                 "depth": self.depth,
+                "subcall_fn": staticmethod(self.subcall_fn) if self.subcall_fn else None,
+                "max_concurrent_subcalls": self.max_concurrent_subcalls,
             },
         )
-        self.proxy_server = HTTPServer(("127.0.0.1", 0), handler)
+        self.proxy_server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.proxy_server.daemon_threads = True
+        # Store the address on the server so handlers read it live; this is what
+        # makes update_handler_address work across persistent multi-turn calls.
+        self.proxy_server.lm_handler_address = self.lm_handler_address
         self.proxy_port = self.proxy_server.server_address[1]
         self.proxy_thread = threading.Thread(target=self.proxy_server.serve_forever, daemon=True)
         self.proxy_thread.start()
@@ -266,32 +534,142 @@ class DockerREPL(NonIsolatedEnv):
             text=True,
         )
         if result.returncode != 0:
+            self.cleanup()
             raise RuntimeError(f"Failed to start container: {result.stderr}")
 
         self.container_id = result.stdout.strip()
 
-        # Install dependencies
+        # Install dependencies. dill is optional (falls back to pickle), but
+        # requests is required for llm_query/rlm_query, so verify it imports.
         subprocess.run(
             ["docker", "exec", self.container_id, "pip", "install", "-q", "dill", "requests"],
             capture_output=True,
         )
+        check = subprocess.run(
+            ["docker", "exec", self.container_id, "python", "-c", "import requests"],
+            capture_output=True,
+            text=True,
+        )
+        if check.returncode != 0:
+            self.cleanup()
+            raise RuntimeError(
+                "Failed to install 'requests' in the docker image; llm_query/rlm_query "
+                f"would not work. Use an image with requests preinstalled. Error: {check.stderr}"
+            )
 
     def load_context(self, context_payload: dict | list | str):
-        """Load context by writing to a file in the mounted workspace."""
+        """Load context as ``context_0`` (with ``context`` aliased to it)."""
+        self.add_context(context_payload, 0)
+
+    # ------------------------------------------------------------------ #
+    # Persistence protocol (SupportsPersistence) - multi-turn sessions
+    # ------------------------------------------------------------------ #
+    def update_handler_address(self, address: tuple[str, int]) -> None:
+        """Point the proxy at a new LM handler (each completion() spawns one).
+
+        This is the per-turn entry point in persistent mode, so it also resets
+        the ``answer`` signal. Unlike the local env (which detects the
+        False->True transition via a callback), the container reads
+        ``answer["ready"]`` from persisted state at the end of each cell, so a
+        stale ``ready=True`` from a previous turn would otherwise short-circuit
+        the next turn immediately.
+        """
+        self.lm_handler_address = address
+        if self.proxy_server is not None:
+            self.proxy_server.lm_handler_address = address
+        self.execute_code("answer = {'content': '', 'ready': False}")
+
+    def add_context(
+        self, context_payload: dict | list | str, context_index: int | None = None
+    ) -> int:
+        """Add a context as ``context_N`` (auto-incrementing unless given).
+
+        ``context`` aliases ``context_0`` for backward compatibility, matching
+        the versioning behavior of the local environment.
+        """
+        if context_index is None:
+            context_index = self._context_count
+
+        var_name = f"context_{context_index}"
         if isinstance(context_payload, str):
-            context_path = os.path.join(self.temp_dir, "context.txt")
-            with open(context_path, "w") as f:
+            fname = f"context_{context_index}.txt"
+            with open(os.path.join(self.temp_dir, fname), "w") as f:
                 f.write(context_payload)
-            self.execute_code(
-                "with open('/workspace/context.txt', 'r') as f:\n    context = f.read()"
-            )
+            code = f"with open('/workspace/{fname}', 'r') as _f:\n    {var_name} = _f.read()"
         else:
-            context_path = os.path.join(self.temp_dir, "context.json")
-            with open(context_path, "w") as f:
+            fname = f"context_{context_index}.json"
+            with open(os.path.join(self.temp_dir, fname), "w") as f:
                 json.dump(context_payload, f)
-            self.execute_code(
-                "import json\nwith open('/workspace/context.json', 'r') as f:\n    context = json.load(f)"
+            code = (
+                "import json\n"
+                f"with open('/workspace/{fname}', 'r') as _f:\n"
+                f"    {var_name} = json.load(_f)"
             )
+        if context_index == 0:
+            code += "\ncontext = context_0"
+        self.execute_code(code)
+
+        self._context_count = max(self._context_count, context_index + 1)
+        return context_index
+
+    def get_context_count(self) -> int:
+        """Return the number of contexts loaded."""
+        return self._context_count
+
+    def add_history(
+        self, message_history: list[dict[str, Any]], history_index: int | None = None
+    ) -> int:
+        """Store a conversation's message history as ``history_N`` in the REPL.
+
+        The list is JSON round-tripped into the container, which also gives the
+        deep-copy semantics required by the persistence protocol. ``history``
+        aliases ``history_0`` (unless compaction owns ``history``).
+        """
+        if history_index is None:
+            history_index = self._history_count
+
+        var_name = f"history_{history_index}"
+        fname = f"history_{history_index}.json"
+        with open(os.path.join(self.temp_dir, fname), "w") as f:
+            json.dump(message_history, f)
+        code = (
+            "import json\n"
+            f"with open('/workspace/{fname}', 'r') as _f:\n"
+            f"    {var_name} = json.load(_f)"
+        )
+        if history_index == 0 and not self.compaction:
+            code += "\nhistory = history_0"
+        self.execute_code(code)
+
+        self._history_count = max(self._history_count, history_index + 1)
+        return history_index
+
+    def get_history_count(self) -> int:
+        """Return the number of conversation histories stored."""
+        return self._history_count
+
+    # ------------------------------------------------------------------ #
+    # Compaction - running, auto-summarized trajectory exposed as `history`
+    # ------------------------------------------------------------------ #
+    def _inject_history(self, history: list[Any]) -> None:
+        """Refresh the container's ``history`` variable from a host-side list."""
+        fname = "_compaction_history.json"
+        with open(os.path.join(self.temp_dir, fname), "w") as f:
+            json.dump(history, f)
+        self.execute_code(
+            f"import json\nwith open('/workspace/{fname}', 'r') as _f:\n    history = json.load(_f)"
+        )
+
+    def append_compaction_entry(self, entry: list[dict[str, Any]] | dict[str, Any]) -> None:
+        """Append a trajectory segment or summary to the compaction history.
+
+        The host keeps the canonical list and re-injects it into the container
+        as ``history`` so model overwrites can't corrupt the accumulated state.
+        """
+        if not self.compaction:
+            return
+        self._compaction_history.append(copy.deepcopy(entry))
+        self._inject_history(self._compaction_history)
 
     def execute_code(self, code: str) -> REPLResult:
         start = time.perf_counter()
@@ -299,9 +677,22 @@ class DockerREPL(NonIsolatedEnv):
         with self._calls_lock:
             self.pending_calls.clear()
 
-        script = _build_exec_script(code, self.proxy_port, self.depth)
+        # Write the exec script into the mounted workspace and run it as a file.
+        # This avoids ARG_MAX / shell-quoting limits from passing huge scripts
+        # via `python -c`.
+        script = _build_exec_script(
+            code,
+            self.proxy_port,
+            self.depth,
+            custom_tools=self.custom_tools,
+            compaction=self.compaction,
+        )
+        script_path = os.path.join(self.temp_dir, "_exec.py")
+        with open(script_path, "w") as f:
+            f.write(script)
+
         result = subprocess.run(
-            ["docker", "exec", self.container_id, "python", "-c", script],
+            ["docker", "exec", self.container_id, "python", "/workspace/_exec.py"],
             capture_output=True,
             text=True,
         )
@@ -312,7 +703,7 @@ class DockerREPL(NonIsolatedEnv):
 
         try:
             lines = result.stdout.strip().split("\n")
-            data = json.loads(lines[-1]) if lines else {}
+            data = json.loads(lines[-1]) if lines and lines[-1] else {}
             return REPLResult(
                 stdout=data.get("stdout", ""),
                 stderr=data.get("stderr", "") + result.stderr,
@@ -331,15 +722,38 @@ class DockerREPL(NonIsolatedEnv):
             )
 
     def cleanup(self):
-        if hasattr(self, "container_id") and self.container_id:
-            subprocess.run(["docker", "stop", self.container_id], capture_output=True)
-            self.container_id = None
-        if hasattr(self, "proxy_server") and self.proxy_server:
-            self.proxy_server.shutdown()
-            self.proxy_server = None
-        if hasattr(self, "temp_dir") and os.path.exists(self.temp_dir):
-            import shutil
+        """Tear down the container, proxy server, and workspace. Idempotent."""
+        if getattr(self, "_cleaned_up", False):
+            return
+        self._cleaned_up = True
 
+        # Force-remove the container (fast; --rm cleans the rest). Best-effort
+        # removal of root-owned workspace files from inside the container first,
+        # so the host rmtree below doesn't leave permission-denied garbage.
+        if getattr(self, "container_id", None):
+            subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    self.container_id,
+                    "sh",
+                    "-c",
+                    "rm -rf /workspace/* /workspace/.[!.]* 2>/dev/null || true",
+                ],
+                capture_output=True,
+            )
+            subprocess.run(["docker", "rm", "-f", self.container_id], capture_output=True)
+            self.container_id = None
+
+        if getattr(self, "proxy_server", None):
+            self.proxy_server.shutdown()
+            self.proxy_server.server_close()
+            self.proxy_server = None
+        if getattr(self, "proxy_thread", None):
+            self.proxy_thread.join(timeout=2)
+            self.proxy_thread = None
+
+        if getattr(self, "temp_dir", None) and os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def __enter__(self):

--- a/rlm/environments/docker_repl.py
+++ b/rlm/environments/docker_repl.py
@@ -505,7 +505,13 @@ class DockerREPL(NonIsolatedEnv):
                 "max_concurrent_subcalls": self.max_concurrent_subcalls,
             },
         )
-        self.proxy_server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        # Bind on all interfaces so the container can reach the proxy via
+        # host.docker.internal. On macOS/Docker Desktop loopback works, but on
+        # native Linux host.docker.internal resolves to the bridge gateway IP
+        # (e.g. 172.17.0.1), which cannot reach a server bound to 127.0.0.1 -
+        # the connection is refused. The port is an ephemeral, short-lived one
+        # serving only LM/RLM proxy calls for this env's container.
+        self.proxy_server = ThreadingHTTPServer(("0.0.0.0", 0), handler)
         self.proxy_server.daemon_threads = True
         # Store the address on the server so handlers read it live; this is what
         # makes update_handler_address work across persistent multi-turn calls.

--- a/tests/test_docker_repl_persistent.py
+++ b/tests/test_docker_repl_persistent.py
@@ -1,0 +1,134 @@
+"""Tests for DockerREPL persistence + compaction features.
+
+These mirror tests/test_local_repl_persistent.py but verify behavior by
+executing code inside the container (docker locals are repr strings, not a live
+host dict). Requires a working Docker daemon; skipped otherwise.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from rlm.environments import SupportsPersistence
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=15).returncode == 0
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _docker_available(), reason="Docker not available")
+
+
+@pytest.fixture
+def repl():
+    from rlm.environments.docker_repl import DockerREPL
+
+    r = DockerREPL()
+    yield r
+    r.cleanup()
+
+
+@pytest.fixture
+def repl_compaction():
+    from rlm.environments.docker_repl import DockerREPL
+
+    r = DockerREPL(compaction=True)
+    yield r
+    r.cleanup()
+
+
+class TestDockerProtocol:
+    def test_satisfies_persistence_protocol(self, repl):
+        assert isinstance(repl, SupportsPersistence)
+
+
+class TestDockerMultiContext:
+    def test_add_context_versioning_and_access(self, repl):
+        repl.add_context("First", 0)
+        repl.add_context("Second", 1)
+        assert repl.get_context_count() == 2
+        r = repl.execute_code("print(f'{context_0}|{context_1}|{context}')")
+        assert r.stdout.strip() == "First|Second|First", (r.stdout, r.stderr)
+
+    def test_add_context_auto_increment(self, repl):
+        assert repl.add_context("A") == 0
+        assert repl.add_context("B") == 1
+        assert repl.get_context_count() == 2
+        r = repl.execute_code("print(context_1)")
+        assert r.stdout.strip() == "B"
+
+    def test_context_alias_points_to_first(self, repl):
+        repl.add_context("First")
+        repl.add_context("Second")
+        r = repl.execute_code("print(context == context_0)")
+        assert r.stdout.strip() == "True"
+
+    def test_dict_context(self, repl):
+        repl.add_context({"k": "v", "n": 5}, 0)
+        r = repl.execute_code("print(context_0['k'], context_0['n'])")
+        assert r.stdout.strip() == "v 5"
+
+
+class TestDockerMultiHistory:
+    def test_add_history_versioning(self, repl):
+        h0 = [{"role": "user", "content": "hi"}]
+        h1 = [{"role": "assistant", "content": "yo"}]
+        assert repl.add_history(h0) == 0
+        assert repl.add_history(h1) == 1
+        assert repl.get_history_count() == 2
+        r = repl.execute_code("print(history_0[0]['content'], history_1[0]['content'])")
+        assert r.stdout.strip() == "hi yo"
+
+    def test_history_alias_points_to_first(self, repl):
+        repl.add_history([{"role": "user", "content": "first"}])
+        r = repl.execute_code("print(history[0]['content'])")
+        assert r.stdout.strip() == "first"
+
+    def test_add_history_deep_copy(self, repl):
+        msgs = [{"role": "user", "content": "orig"}]
+        repl.add_history(msgs)
+        # Mutating the caller's list must not affect the stored history.
+        msgs[0]["content"] = "mutated"
+        r = repl.execute_code("print(history_0[0]['content'])")
+        assert r.stdout.strip() == "orig"
+
+
+class TestDockerUpdateHandlerAddress:
+    def test_update_handler_address(self, repl):
+        repl.update_handler_address(("127.0.0.1", 6000))
+        assert repl.lm_handler_address == ("127.0.0.1", 6000)
+        assert repl.proxy_server.lm_handler_address == ("127.0.0.1", 6000)
+
+
+class TestDockerCompaction:
+    def test_history_seeded_as_list(self, repl_compaction):
+        r = repl_compaction.execute_code("print(type(history).__name__, len(history))")
+        assert r.stdout.strip() == "list 0"
+
+    def test_append_compaction_entry(self, repl_compaction):
+        repl_compaction.append_compaction_entry([{"role": "user", "content": "turn1"}])
+        repl_compaction.append_compaction_entry({"type": "summary", "content": "did stuff"})
+        r = repl_compaction.execute_code(
+            "print(len(history)); print(history[1]['type']); print(history[1]['content'])"
+        )
+        lines = r.stdout.strip().split("\n")
+        assert lines == ["2", "summary", "did stuff"], (r.stdout, r.stderr)
+
+    def test_append_ignored_without_compaction(self, repl):
+        # Non-compaction env: append is a no-op and must not error.
+        repl.append_compaction_entry({"type": "summary", "content": "x"})
+
+    def test_history_survives_model_overwrite(self, repl_compaction):
+        repl_compaction.append_compaction_entry({"type": "summary", "content": "keep"})
+        # Model clobbers history mid-cell...
+        repl_compaction.execute_code("history = 'corrupted'")
+        # ...next append must restore the canonical accumulated list.
+        repl_compaction.append_compaction_entry({"type": "summary", "content": "keep2"})
+        r = repl_compaction.execute_code("print(len(history)); print(history[-1]['content'])")
+        assert r.stdout.strip().split("\n") == ["2", "keep2"], (r.stdout, r.stderr)

--- a/tests/test_docker_repl_robustness.py
+++ b/tests/test_docker_repl_robustness.py
@@ -1,0 +1,623 @@
+"""Expansive robustness / bug-hunting tests for DockerREPL.
+
+Focus areas:
+  - sub-calling behavior (llm_query / rlm_query, batched, fallback, errors,
+    ordering, concurrency bounds, call tracking)
+  - scaffold restoration (model overwriting reserved names)
+  - answer-dict semantics + the per-turn reset regression
+  - custom-tool injection edge cases
+  - REPL state / output robustness
+  - multi-instance isolation and lifecycle
+
+All tests use a mock LM + mock subcall_fn (no API cost). Requires a working
+Docker daemon; skipped otherwise.
+"""
+
+import asyncio
+import shutil
+import subprocess
+import threading
+import time
+
+import pytest
+
+from rlm.clients.base_lm import BaseLM
+from rlm.core.lm_handler import LMHandler
+from rlm.core.types import ModelUsageSummary, RLMChatCompletion, UsageSummary
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=15).returncode == 0
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _docker_available(), reason="Docker not available")
+
+
+# --------------------------------------------------------------------------- #
+# Mock LM + helpers
+# --------------------------------------------------------------------------- #
+class EchoLM(BaseLM):
+    """Deterministic mock LM. Optional delay to exercise concurrency."""
+
+    def __init__(self, delay: float = 0.0):
+        super().__init__(model_name="echo")
+        self.delay = delay
+
+    def completion(self, prompt, model=None):
+        if self.delay:
+            time.sleep(self.delay)
+        return f"echo:{str(prompt)[:40]}"
+
+    async def acompletion(self, prompt, model=None):
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return f"echo:{str(prompt)[:40]}"
+
+    def get_usage_summary(self):
+        return UsageSummary({"echo": ModelUsageSummary(1, 10, 10)})
+
+    def get_last_usage(self):
+        return ModelUsageSummary(1, 10, 10)
+
+
+def _completion(response: str, model: str | None = None) -> RLMChatCompletion:
+    return RLMChatCompletion(
+        root_model=model or "child",
+        prompt="p",
+        response=response,
+        usage_summary=UsageSummary(model_usage_summaries={}),
+        execution_time=0.0,
+    )
+
+
+def make_repl(subcall_fn=None, with_handler=True, **kwargs):
+    """Create a DockerREPL (optionally) wired to an EchoLM handler."""
+    from rlm.environments.docker_repl import DockerREPL
+
+    handler = None
+    addr = None
+    if with_handler:
+        handler = LMHandler(client=kwargs.pop("lm_client", EchoLM()))
+        handler.start()
+        addr = handler.address
+    repl = DockerREPL(lm_handler_address=addr, subcall_fn=subcall_fn, **kwargs)
+    repl._test_handler = handler  # keep a ref so we can stop it on cleanup
+    return repl
+
+
+def teardown_repl(repl):
+    repl.cleanup()
+    if getattr(repl, "_test_handler", None) is not None:
+        repl._test_handler.stop()
+
+
+# =========================================================================== #
+# Sub-calling: llm_query / llm_query_batched
+# =========================================================================== #
+class TestLLMQuery:
+    def test_llm_query_and_tracking(self):
+        repl = make_repl()
+        try:
+            r = repl.execute_code("print(llm_query('hi'))")
+            assert r.stdout.strip() == "echo:hi", (r.stdout, r.stderr)
+            assert len(r.rlm_calls) == 1
+        finally:
+            teardown_repl(repl)
+
+    def test_llm_query_batched_order_and_tracking(self):
+        repl = make_repl()
+        try:
+            r = repl.execute_code("print(llm_query_batched(['a', 'b', 'c']))")
+            assert "echo:a" in r.stdout and "echo:c" in r.stdout
+            assert len(r.rlm_calls) == 3
+        finally:
+            teardown_repl(repl)
+
+    def test_pending_calls_cleared_between_executions(self):
+        """A subsequent execution with no LM calls must report zero rlm_calls."""
+        repl = make_repl()
+        try:
+            r1 = repl.execute_code("llm_query('one')")
+            assert len(r1.rlm_calls) == 1
+            r2 = repl.execute_code("x = 5")
+            assert len(r2.rlm_calls) == 0, "stale pending calls leaked into next execution"
+        finally:
+            teardown_repl(repl)
+
+    def test_llm_query_no_handler_errors_gracefully(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code("print(llm_query('hi'))")
+            assert "Error" in r.stdout
+            assert len(r.rlm_calls) == 0
+        finally:
+            teardown_repl(repl)
+
+    def test_concurrent_llm_query_from_container_threads(self):
+        """Many concurrent llm_query calls from container threads must all
+        complete (no serialization/deadlock) and all be tracked. Uses a slow
+        LM so serialization would blow the time budget."""
+        repl = make_repl(lm_client=EchoLM(delay=0.3))
+        code = (
+            "import threading\n"
+            "res = {}\n"
+            "def w(i):\n"
+            "    res[i] = llm_query(f'q{i}')\n"
+            "ts = [threading.Thread(target=w, args=(i,)) for i in range(5)]\n"
+            "[t.start() for t in ts]\n"
+            "[t.join() for t in ts]\n"
+            "print(sorted(res.keys()))\n"
+            "print(all(v.startswith('echo:') for v in res.values()))"
+        )
+        try:
+            t0 = time.monotonic()
+            r = repl.execute_code(code)
+            dt = time.monotonic() - t0
+            lines = r.stdout.strip().split("\n")
+            assert lines[0] == "[0, 1, 2, 3, 4]", (r.stdout, r.stderr)
+            assert lines[1] == "True"
+            assert len(r.rlm_calls) == 5
+            # 5 x 0.3s sequential = 1.5s; concurrent should be well under.
+            assert dt < 1.2, f"concurrent llm_query appears serialized: {dt:.2f}s"
+        finally:
+            teardown_repl(repl)
+
+
+# =========================================================================== #
+# Sub-calling: rlm_query / rlm_query_batched
+# =========================================================================== #
+class TestRLMQuery:
+    def test_rlm_query_uses_subcall_fn(self):
+        repl = make_repl(subcall_fn=lambda p, m=None: _completion(f"child:{p}"))
+        try:
+            r = repl.execute_code("print(rlm_query('task'))")
+            assert r.stdout.strip() == "child:task", (r.stdout, r.stderr)
+            assert len(r.rlm_calls) == 1
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_model_override_propagates(self):
+        seen = {}
+
+        def sub(p, m=None):
+            seen["model"] = m
+            return _completion("ok", model=m)
+
+        repl = make_repl(subcall_fn=sub)
+        try:
+            repl.execute_code("rlm_query('task', model='custom-1')")
+            assert seen["model"] == "custom-1"
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_fallback_to_llm_when_no_subcall(self):
+        """No subcall_fn but a handler -> rlm_query degrades to a plain LM call."""
+        repl = make_repl(subcall_fn=None, with_handler=True)
+        try:
+            r = repl.execute_code("print(rlm_query('task'))")
+            assert r.stdout.strip() == "echo:task", (r.stdout, r.stderr)
+            assert len(r.rlm_calls) == 1
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_error_is_caught(self):
+        def boom(p, m=None):
+            raise RuntimeError("subcall exploded")
+
+        repl = make_repl(subcall_fn=boom)
+        try:
+            r = repl.execute_code("print(rlm_query('task'))")
+            assert "Error" in r.stdout and "subcall exploded" in r.stdout
+            assert r.stderr.strip() == "", "error should be returned as value, not raised"
+            assert len(r.rlm_calls) == 0
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_batched_basic_order_and_tracking(self):
+        repl = make_repl(subcall_fn=lambda p, m=None: _completion(f"c:{p}"))
+        try:
+            r = repl.execute_code("print(rlm_query_batched(['p0', 'p1', 'p2']))")
+            assert "['c:p0', 'c:p1', 'c:p2']" in r.stdout, (r.stdout, r.stderr)
+            assert [c.response for c in r.rlm_calls] == ["c:p0", "c:p1", "c:p2"]
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_batched_empty(self):
+        called = []
+        repl = make_repl(subcall_fn=lambda p, m=None: called.append(p) or _completion("x"))
+        try:
+            r = repl.execute_code("print(rlm_query_batched([]))")
+            assert r.stdout.strip() == "[]"
+            assert called == []
+            assert len(r.rlm_calls) == 0
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_batched_single(self):
+        repl = make_repl(subcall_fn=lambda p, m=None: _completion(f"c:{p}"))
+        try:
+            r = repl.execute_code("print(rlm_query_batched(['only']))")
+            assert r.stdout.strip() == "['c:only']"
+            assert len(r.rlm_calls) == 1
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_batched_order_preserved_under_varying_delays(self):
+        def sub(p, m=None):
+            # earlier prompts sleep longer so completion order != input order
+            delay = {"p0": 0.3, "p1": 0.2, "p2": 0.1, "p3": 0.0}[p]
+            time.sleep(delay)
+            return _completion(f"r:{p}")
+
+        repl = make_repl(subcall_fn=sub, max_concurrent_subcalls=4)
+        try:
+            r = repl.execute_code("print(rlm_query_batched(['p0', 'p1', 'p2', 'p3']))")
+            assert "['r:p0', 'r:p1', 'r:p2', 'r:p3']" in r.stdout, (r.stdout, r.stderr)
+            # tracked metadata also in prompt order
+            assert [c.response for c in r.rlm_calls] == ["r:p0", "r:p1", "r:p2", "r:p3"]
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_batched_partial_failure_excludes_from_tracking(self):
+        def sub(p, m=None):
+            if p == "bad":
+                raise ValueError("nope")
+            return _completion(f"ok:{p}")
+
+        repl = make_repl(subcall_fn=sub, max_concurrent_subcalls=4)
+        try:
+            r = repl.execute_code("print(rlm_query_batched(['good1', 'bad', 'good2']))")
+            assert "ok:good1" in r.stdout and "ok:good2" in r.stdout
+            assert "Error" in r.stdout and "nope" in r.stdout
+            # only successful completions tracked, in order
+            assert [c.response for c in r.rlm_calls] == ["ok:good1", "ok:good2"]
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_batched_respects_max_concurrent(self):
+        active = [0]
+        peak = [0]
+        lk = threading.Lock()
+
+        def sub(p, m=None):
+            with lk:
+                active[0] += 1
+                peak[0] = max(peak[0], active[0])
+            time.sleep(0.1)
+            with lk:
+                active[0] -= 1
+            return _completion(f"ok:{p}")
+
+        repl = make_repl(subcall_fn=sub, max_concurrent_subcalls=2)
+        try:
+            r = repl.execute_code("print(len(rlm_query_batched(['a', 'b', 'c', 'd', 'e', 'f'])))")
+            assert r.stdout.strip() == "6", (r.stdout, r.stderr)
+            assert peak[0] <= 2, f"concurrency bound violated: peak={peak[0]}"
+            assert len(r.rlm_calls) == 6
+        finally:
+            teardown_repl(repl)
+
+    def test_rlm_query_batched_fallback_when_no_subcall(self):
+        repl = make_repl(subcall_fn=None, with_handler=True)
+        try:
+            r = repl.execute_code("print(rlm_query_batched(['a', 'b']))")
+            assert "echo:a" in r.stdout and "echo:b" in r.stdout
+            assert len(r.rlm_calls) == 2
+        finally:
+            teardown_repl(repl)
+
+    def test_malformed_subcall_result_does_not_hang(self):
+        """If subcall_fn returns a non-completion object, the container must get
+        a structured error promptly (not hang on a dropped connection), and the
+        bad result must not be tracked."""
+        repl = make_repl(subcall_fn=lambda p, m=None: 12345)  # no .response attr
+        try:
+            t0 = time.monotonic()
+            r = repl.execute_code("print(rlm_query('task'))")
+            dt = time.monotonic() - t0
+            assert "Error" in r.stdout, (r.stdout, r.stderr)
+            assert dt < 30, f"appears to have hung: {dt:.1f}s"
+            assert len(r.rlm_calls) == 0
+        finally:
+            teardown_repl(repl)
+
+    def test_mixed_llm_and_rlm_calls_tracked_in_order(self):
+        repl = make_repl(subcall_fn=lambda p, m=None: _completion(f"c:{p}"))
+        try:
+            r = repl.execute_code(
+                "llm_query('first')\nrlm_query_batched(['b', 'c'])\nllm_query('last')"
+            )
+            responses = [c.response for c in r.rlm_calls]
+            assert responses == ["echo:first", "c:b", "c:c", "echo:last"], responses
+        finally:
+            teardown_repl(repl)
+
+
+# =========================================================================== #
+# Scaffold restoration (model overwriting reserved names)
+# =========================================================================== #
+class TestScaffoldRestoration:
+    def test_overwritten_llm_query_restored_next_cell(self):
+        repl = make_repl()
+        try:
+            repl.execute_code("llm_query = lambda *a, **k: 'HIJACKED'")
+            r = repl.execute_code("print(llm_query('hi'))")
+            assert r.stdout.strip() == "echo:hi", "llm_query not restored after overwrite"
+        finally:
+            teardown_repl(repl)
+
+    def test_overwritten_rlm_query_restored_next_cell(self):
+        repl = make_repl(subcall_fn=lambda p, m=None: _completion("real"))
+        try:
+            repl.execute_code("rlm_query = 'garbage'")
+            r = repl.execute_code("print(rlm_query('x'))")
+            assert r.stdout.strip() == "real", "rlm_query not restored after overwrite"
+        finally:
+            teardown_repl(repl)
+
+    def test_overwritten_show_vars_restored(self):
+        repl = make_repl(with_handler=False)
+        try:
+            repl.execute_code("SHOW_VARS = 123")
+            r = repl.execute_code("print(SHOW_VARS())")
+            assert "variables" in r.stdout.lower(), r.stdout
+        finally:
+            teardown_repl(repl)
+
+    def test_context_alias_restored_after_overwrite(self):
+        repl = make_repl(with_handler=False, context_payload="ORIGINAL")
+        try:
+            repl.execute_code("context = 'clobbered'")
+            r = repl.execute_code("print(context)")
+            assert r.stdout.strip() == "ORIGINAL", "context alias not restored to context_0"
+        finally:
+            teardown_repl(repl)
+
+
+# =========================================================================== #
+# answer dict semantics
+# =========================================================================== #
+class TestAnswerSemantics:
+    def test_answer_ready_surfaces_final_answer(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code("answer['content'] = 'done'; answer['ready'] = True")
+            assert r.final_answer == "done"
+        finally:
+            teardown_repl(repl)
+
+    def test_answer_not_ready_is_none(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code("answer['content'] = 'partial'")
+            assert r.final_answer is None
+        finally:
+            teardown_repl(repl)
+
+    def test_answer_empty_content_surfaces_empty_string(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code("answer['ready'] = True")
+            assert r.final_answer == "", f"expected '' got {r.final_answer!r}"
+        finally:
+            teardown_repl(repl)
+
+    def test_answer_nonstring_content_coerced(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code("answer['content'] = 1234; answer['ready'] = True")
+            assert r.final_answer == "1234"
+        finally:
+            teardown_repl(repl)
+
+    def test_answer_plain_dict_reassignment_surfaces(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code("answer = {'content': 'X', 'ready': True}")
+            assert r.final_answer == "X"
+        finally:
+            teardown_repl(repl)
+
+    def test_update_handler_address_resets_stale_answer(self):
+        """Regression: stale answer.ready from a prior turn must not leak into
+        the next turn (persistent multi-turn)."""
+        repl = make_repl()
+        try:
+            r1 = repl.execute_code("answer['content'] = 'stale'; answer['ready'] = True")
+            assert r1.final_answer == "stale"
+            repl.update_handler_address(repl.lm_handler_address)
+            r2 = repl.execute_code("print(answer['ready'], repr(answer['content']))")
+            assert r2.stdout.strip() == "False ''", r2.stdout
+            assert r2.final_answer is None
+        finally:
+            teardown_repl(repl)
+
+
+# =========================================================================== #
+# Custom tools
+# =========================================================================== #
+class TestCustomTools:
+    def test_reserved_name_rejected(self):
+        from rlm.environments.docker_repl import DockerREPL
+
+        with pytest.raises(ValueError, match="reserved"):
+            DockerREPL(custom_tools={"llm_query": "def llm_query(): pass"})
+
+    def test_code_string_and_data_tools(self):
+        repl = make_repl(
+            with_handler=False,
+            custom_tools={
+                "square": "def square(x):\n    return x * x",
+                "CFG": {"mode": "t", "vals": [1, 2, 3]},
+            },
+        )
+        try:
+            r = repl.execute_code("print(square(CFG['vals'][2]))")
+            assert r.stdout.strip() == "9", (r.stdout, r.stderr)
+        finally:
+            teardown_repl(repl)
+
+    def test_host_callable_tool_skipped_without_crash(self):
+        repl = make_repl(with_handler=False, custom_tools={"hostfn": lambda x: x})
+        try:
+            # The repl still builds and runs; the tool is simply absent.
+            r = repl.execute_code("print('ok')")
+            assert r.stdout.strip() == "ok"
+            r2 = repl.execute_code("print(hostfn(1))")
+            assert "NameError" in r2.stderr or "Error" in r2.stderr
+        finally:
+            teardown_repl(repl)
+
+    def test_data_tool_with_special_characters_roundtrips(self):
+        tricky = {"q": 'he said "hi"', "s": "a'b\\c", "nl": "x\ny", "u": "café ☕"}
+        repl = make_repl(with_handler=False, custom_tools={"DATA": tricky})
+        try:
+            r = repl.execute_code(
+                "print(DATA['q']); print(DATA['s']); print(repr(DATA['nl'])); print(DATA['u'])"
+            )
+            lines = r.stdout.split("\n")
+            assert lines[0] == 'he said "hi"', (r.stdout, r.stderr)
+            assert lines[1] == "a'b\\c"
+            assert lines[2] == "'x\\ny'"
+            assert lines[3] == "café ☕"
+        finally:
+            teardown_repl(repl)
+
+
+# =========================================================================== #
+# REPL state / output robustness
+# =========================================================================== #
+class TestStateAndOutput:
+    def test_unpicklable_dropped_picklable_survives(self):
+        # A generator is genuinely unserializable (even by dill); it must be
+        # dropped from persisted state without crashing, while picklable state
+        # survives across executions.
+        repl = make_repl(with_handler=False)
+        try:
+            repl.execute_code("gen = (i for i in range(3))\nkeep = 42")
+            r = repl.execute_code("print(keep)")
+            assert r.stdout.strip() == "42", "picklable var lost across executions"
+            r2 = repl.execute_code("print('gen' in dir())")
+            assert r2.stdout.strip() == "False", "unpicklable var unexpectedly persisted"
+        finally:
+            teardown_repl(repl)
+
+    def test_unicode_stdout(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code("print('café ☕ 日本語')")
+            assert r.stdout.strip() == "café ☕ 日本語", repr(r.stdout)
+        finally:
+            teardown_repl(repl)
+
+    def test_output_that_looks_like_json_is_preserved(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code('print(\'{"fake": "json", "n": 1}\')\nprint("second line")')
+            assert '{"fake": "json", "n": 1}' in r.stdout
+            assert "second line" in r.stdout
+        finally:
+            teardown_repl(repl)
+
+    def test_exception_produces_stderr_not_crash(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code("print('before')\nraise ValueError('kaboom')")
+            assert "before" in r.stdout
+            assert "ValueError" in r.stderr and "kaboom" in r.stderr
+            assert r.final_answer is None
+        finally:
+            teardown_repl(repl)
+
+    def test_empty_code(self):
+        repl = make_repl(with_handler=False)
+        try:
+            r = repl.execute_code("")
+            assert r.stderr.strip() == "", r.stderr
+        finally:
+            teardown_repl(repl)
+
+    def test_large_context_via_mount(self):
+        big = "\n".join(f"line {i}" for i in range(20000))
+        repl = make_repl(with_handler=False, context_payload=big)
+        try:
+            r = repl.execute_code(
+                "print(len(context.splitlines())); print(context.splitlines()[12345])"
+            )
+            lines = r.stdout.strip().split("\n")
+            assert lines[0] == "20000", (r.stdout, r.stderr)
+            assert lines[1] == "line 12345"
+        finally:
+            teardown_repl(repl)
+
+    def test_dict_context_nested_access(self):
+        repl = make_repl(with_handler=False, context_payload={"a": {"b": [10, 20, 30]}})
+        try:
+            r = repl.execute_code("print(context['a']['b'][1])")
+            assert r.stdout.strip() == "20"
+        finally:
+            teardown_repl(repl)
+
+
+# =========================================================================== #
+# Multi-instance isolation & lifecycle
+# =========================================================================== #
+class TestIsolationAndLifecycle:
+    def test_two_repls_isolated_state_and_tracking(self):
+        r1 = make_repl(subcall_fn=lambda p, m=None: _completion("A"))
+        r2 = make_repl(subcall_fn=lambda p, m=None: _completion("B"))
+        try:
+            r1.execute_code("shared = 'from_r1'")
+            r2.execute_code("shared = 'from_r2'")
+            o1 = r1.execute_code("print(shared)")
+            o2 = r2.execute_code("print(shared)")
+            assert o1.stdout.strip() == "from_r1"
+            assert o2.stdout.strip() == "from_r2"
+            # call tracking is independent
+            t1 = r1.execute_code("rlm_query('x')")
+            assert [c.response for c in t1.rlm_calls] == ["A"]
+            t2 = r2.execute_code("rlm_query('x')")
+            assert [c.response for c in t2.rlm_calls] == ["B"]
+            assert r1.proxy_port != r2.proxy_port
+            assert r1.container_id != r2.container_id
+        finally:
+            teardown_repl(r1)
+            teardown_repl(r2)
+
+    def test_double_cleanup_idempotent(self):
+        repl = make_repl(with_handler=False)
+        repl.execute_code("x = 1")
+        cid = repl.container_id
+        repl.cleanup()
+        repl.cleanup()  # must not raise
+        if repl._test_handler is not None:
+            repl._test_handler.stop()
+        # container removed
+        out = subprocess.run(
+            ["docker", "ps", "-a", "-q", "--filter", f"id={cid}"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert out == "", f"container not removed: {out!r}"
+
+    def test_context_manager_cleans_up(self):
+        from rlm.environments.docker_repl import DockerREPL
+
+        with DockerREPL() as repl:
+            cid = repl.container_id
+            tmp = repl.temp_dir
+            repl.execute_code("x = 1")
+        out = subprocess.run(
+            ["docker", "ps", "-a", "-q", "--filter", f"id={cid}"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert out == ""
+        import os
+
+        assert not os.path.exists(tmp)

--- a/tests/test_multi_turn_integration.py
+++ b/tests/test_multi_turn_integration.py
@@ -335,7 +335,7 @@ class TestPersistentModeValidation:
             RLM(
                 backend="openai",
                 backend_kwargs={"model_name": "test"},
-                environment="docker",  # Not supported for persistent
+                environment="modal",  # Isolated env without persistence support
                 persistent=True,
             )
 
@@ -346,6 +346,18 @@ class TestPersistentModeValidation:
             backend="openai",
             backend_kwargs={"model_name": "test"},
             environment="local",
+            persistent=True,
+        )
+        assert rlm.persistent is True
+
+    def test_docker_environment_supported(self):
+        """Docker environment should support persistent mode (no error at init)."""
+        # Should not raise during validation (container is only created on
+        # completion(), so this stays lightweight).
+        rlm = RLM(
+            backend="openai",
+            backend_kwargs={"model_name": "test"},
+            environment="docker",
             persistent=True,
         )
         assert rlm.persistent is True


### PR DESCRIPTION
Brings DockerREPL to full parity with the local environment — sub-LLM and sub-RLM calls,
  custom tools, multi-turn persistence, and compaction — while fixing deadlock and cleanup bugs
  in the sub-agent path. Verified end-to-end against a real model.

  Bug fixes

  - Deadlock: single-threaded proxy → ThreadingHTTPServer, so concurrent sub-calls no longer
  serialize behind one in-flight request.
  - Cleanup: idempotent teardown, force-removes the container, joins the proxy thread, and
  clears root-owned files from the bind mount (fixes Linux leftovers).
  - Hangs: proxy dispatch wrapped to return a structured error instead of dropping the
  connection on an unexpected handler exception.
  - Stale answer: reset the answer signal at each turn boundary so a previous turn's ready=True
  can't short-circuit the next.
  - Exec robustness: run scripts from a mounted file (no ARG_MAX/quoting limits); verify
  requests installed.

  unexpected handler exception.
  - Stale answer: reset the answer signal at each turn boundary so a previous turn's ready=True can't
  short-circuit the next.
  - Exec robustness: run scripts from a mounted file (no ARG_MAX/quoting limits); verify requests installed.

  Features added

  - Sub-RLM: rlm_query / rlm_query_batched with /rlm_query* proxy endpoints; batched calls run in parallel
  (bounded by max_concurrent_subcalls), order-preserving.
  - Custom tools: custom_tools / custom_sub_tools injected into the container.
  - Persistence: implements SupportsPersistence — versioned context_N/history_N reused across completion() calls.
  - Compaction: auto-summarized history, kept canonical host-side so model overwrites can't corrupt it.
