### PR TITLE
fix: salvage REPL state on mid-block exceptions instead of discarding it

### DIFF
--- a/rlm/environments/daytona_repl.py
+++ b/rlm/environments/daytona_repl.py
@@ -337,7 +337,14 @@ try:
         if key not in _globals and not key.startswith("_"):
             _locals[key] = value
 except Exception as e:
+    # combined is mutated in place by exec, so variables assigned before the
+    # exception are present -- salvage them instead of discarding paid-for
+    # work (e.g. sub-call results from a loop that raised late).
+    for key, value in combined.items():
+        if key not in _globals and not key.startswith("_"):
+            _locals[key] = value
     traceback.print_exc(file=stderr_buf)
+    print("\\n(variables assigned before the error were preserved)", file=stderr_buf)
 finally:
     sys.stdout = old_stdout
     sys.stderr = old_stderr

--- a/rlm/environments/docker_repl.py
+++ b/rlm/environments/docker_repl.py
@@ -381,7 +381,14 @@ try:
         if k not in _globals and not k.startswith("_"):
             _locals[k] = v
 except Exception:
+    # combined is mutated in place by exec, so variables assigned before the
+    # exception are present -- salvage them instead of discarding paid-for
+    # work (e.g. sub-call results from a loop that raised late).
+    for k, v in combined.items():
+        if k not in _globals and not k.startswith("_"):
+            _locals[k] = v
     traceback.print_exc(file=stderr_buf)
+    print("\\n(variables assigned before the error were preserved)", file=stderr_buf)
 finally:
     sys.stdout, sys.stderr = old_stdout, old_stderr
 

--- a/rlm/environments/e2b_repl.py
+++ b/rlm/environments/e2b_repl.py
@@ -232,7 +232,14 @@ try:
         if key not in _globals and not key.startswith("_"):
             _locals[key] = value
 except Exception as e:
+    # combined is mutated in place by exec, so variables assigned before the
+    # exception are present -- salvage them instead of discarding paid-for
+    # work (e.g. sub-call results from a loop that raised late).
+    for key, value in combined.items():
+        if key not in _globals and not key.startswith("_"):
+            _locals[key] = value
     traceback.print_exc(file=stderr_buf)
+    print("\\n(variables assigned before the error were preserved)", file=stderr_buf)
 finally:
     sys.stdout = old_stdout
     sys.stderr = old_stderr

--- a/rlm/environments/local_repl.py
+++ b/rlm/environments/local_repl.py
@@ -567,8 +567,20 @@ class LocalREPL(NonIsolatedEnv):
                 stdout = stdout_buf.getvalue()
                 stderr = stderr_buf.getvalue()
             except Exception as e:
+                # `combined` is mutated in place by exec, so variables assigned
+                # before the exception are present — salvage them instead of
+                # discarding paid-for work (e.g. sub-call results from a loop
+                # that raised late).
+                for key, value in combined.items():
+                    if key not in self.globals and not key.startswith("_"):
+                        self.locals[key] = value
+                self._restore_scaffold()
                 stdout = stdout_buf.getvalue()
-                stderr = stderr_buf.getvalue() + f"\n{type(e).__name__}: {e}"
+                stderr = (
+                    stderr_buf.getvalue()
+                    + f"\n{type(e).__name__}: {e}"
+                    + "\n(variables assigned before the error were preserved)"
+                )
 
         final_answer = self._last_final_answer
         self._last_final_answer = None

--- a/rlm/environments/modal_repl.py
+++ b/rlm/environments/modal_repl.py
@@ -249,7 +249,14 @@ try:
         if key not in _globals and not key.startswith("_"):
             _locals[key] = value
 except Exception as e:
+    # combined is mutated in place by exec, so variables assigned before the
+    # exception are present -- salvage them instead of discarding paid-for
+    # work (e.g. sub-call results from a loop that raised late).
+    for key, value in combined.items():
+        if key not in _globals and not key.startswith("_"):
+            _locals[key] = value
     traceback.print_exc(file=stderr_buf)
+    print("\\n(variables assigned before the error were preserved)", file=stderr_buf)
 finally:
     sys.stdout = old_stdout
     sys.stderr = old_stderr

--- a/rlm/environments/prime_repl.py
+++ b/rlm/environments/prime_repl.py
@@ -248,7 +248,14 @@ try:
         if key not in _globals and not key.startswith("_"):
             _locals[key] = value
 except Exception as e:
+    # combined is mutated in place by exec, so variables assigned before the
+    # exception are present -- salvage them instead of discarding paid-for
+    # work (e.g. sub-call results from a loop that raised late).
+    for key, value in combined.items():
+        if key not in _globals and not key.startswith("_"):
+            _locals[key] = value
     traceback.print_exc(file=stderr_buf)
+    print("\\n(variables assigned before the error were preserved)", file=stderr_buf)
 finally:
     sys.stdout = old_stdout
     sys.stderr = old_stderr

--- a/tests/repl/test_local_repl.py
+++ b/tests/repl/test_local_repl.py
@@ -21,3 +21,64 @@ def test_persistent_execution():
     assert "50" in result3.stdout
 
     repl.cleanup()
+
+
+def test_failed_block_preserves_prior_assignments():
+    repl = LocalREPL()
+    result = repl.execute_code("a = 1\nb = 2\nraise ValueError('boom at item 3')\nc = 3")
+    # assignments before the raise survive
+    assert repl.locals["a"] == 1
+    assert repl.locals["b"] == 2
+    # the line after the raise never ran
+    assert "c" not in repl.locals
+    # error still surfaced to the model, plus the salvage note
+    assert "ValueError" in result.stderr
+    assert "boom at item 3" in result.stderr
+    assert "preserved" in result.stderr
+    # REPL still usable afterwards (scaffold intact)
+    follow = repl.execute_code("d = a + b")
+    assert follow.stderr == ""
+    assert repl.locals["d"] == 3
+    repl.cleanup()
+
+
+def test_failed_block_restores_shadowed_scaffold():
+    repl = LocalREPL()
+    repl.load_context("the real context")
+    # shadow a reserved name, then raise
+    repl.execute_code("context = 'clobbered'\nraise RuntimeError('x')")
+    # scaffold name restored despite the failure
+    assert repl.locals.get("context") != "clobbered"
+    # llm_query still callable (a plain follow-up block runs cleanly)
+    follow = repl.execute_code("z = 5")
+    assert follow.stderr == ""
+    repl.cleanup()
+
+
+def test_salvaged_results_reused_after_midloop_failure():
+    """Integration: a loop that fails at item N can resume from N, not re-run."""
+    repl = LocalREPL()
+    # fake sub-call that raises on its 8th invocation, counting every call
+    repl.execute_code(
+        "calls = []\n"
+        "def fake_query(i):\n"
+        "    calls.append(i)\n"
+        "    if len(calls) == 8:\n"
+        "        raise RuntimeError('transient failure')\n"
+        "    return f'label-{i}'\n"
+    )
+    # first attempt dies mid-loop; 7 paid-for results must survive
+    result = repl.execute_code(
+        "results = []\nfor i in range(10):\n    results.append(fake_query(i))\n"
+    )
+    assert "transient failure" in result.stderr
+    assert repl.locals["results"] == [f"label-{i}" for i in range(7)]
+    # second block resumes from where it left off — no re-paying for items 0-6
+    follow = repl.execute_code(
+        "for i in range(len(results), 10):\n    results.append(fake_query(i))\n"
+    )
+    assert follow.stderr == ""
+    assert repl.locals["results"] == [f"label-{i}" for i in range(10)]
+    # 10 successful calls + 1 failed call = 11 total, not 17+
+    assert len(repl.locals["calls"]) == 11
+    repl.cleanup()


### PR DESCRIPTION
## What this fixes

When code running in a REPL block throws an exception partway through, every environment (`local`, `docker`, `daytona`, `e2b`, `modal`, `prime`) discards all variables that block had already assigned — even ones from expensive work like a loop of `llm_query`/`rlm_query` sub-calls. The model has no way to know earlier sub-calls succeeded, so it usually redoes the whole loop next turn, re-paying for calls it already made.

## The fix

On an exception, save the variables that were assigned before the crash into the persistent namespace (the same copy the success path already does), and tell the model in stderr that this happened. Now a failed loop can resume where it left off instead of starting over.

`ipython_repl.py` didn't need this — it runs cells through a real IPython kernel, which already keeps its namespace after a failed cell.

## Testing

- `ruff check` / `ruff format --check`: clean.
- Full test suite: passes, no new failures.
- Added 3 tests to `tests/repl/test_local_repl.py`: prior variables survive a raise, scaffold names still restore after a failure, and a loop that fails on call 8 of 10 resumes from call 8 instead of redoing 1-7.